### PR TITLE
Add option to use EntityDamageEvent instead of EntityDamageByEntityEvent.

### DIFF
--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleFishingKnockback.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleFishingKnockback.java
@@ -75,7 +75,7 @@ public class ModuleFishingKnockback extends Module {
 		double damage = module().getDouble("damage");
 		if(damage<0) damage = 0.2;
 
-		EntityDamageByEntityEvent event = makeEvent(rodder, player, damage);
+		EntityDamageEvent event = makeEvent(rodder, player, damage);
 		Bukkit.getPluginManager().callEvent(event);
 
 		if(module().getBoolean("checkCancelled") && event.isCancelled()){
@@ -100,8 +100,12 @@ public class ModuleFishingKnockback extends Module {
 		player.setVelocity(loc.subtract(rodder.getLocation()).toVector().normalize().multiply(0.4));
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	private EntityDamageByEntityEvent makeEvent(Player rodder, Player player, double damage) {
-		return new EntityDamageByEntityEvent(rodder, player, EntityDamageEvent.DamageCause.ENTITY_ATTACK, new EnumMap(ImmutableMap.of(EntityDamageEvent.DamageModifier.BASE, damage)), new EnumMap(ImmutableMap.of(EntityDamageEvent.DamageModifier.BASE, Functions.constant(damage))));
+	@SuppressWarnings({ "rawtypes", "unchecked", "deprecation" })
+	private EntityDamageEvent makeEvent(Player rodder, Player player, double damage) {
+	    if (module().getBoolean("useEntityDamageEvent")) {
+	        return new EntityDamageEvent(player, EntityDamageEvent.DamageCause.ENTITY_ATTACK, damage);
+	    } else {
+	        return new EntityDamageByEntityEvent(rodder, player, EntityDamageEvent.DamageCause.ENTITY_ATTACK, new EnumMap(ImmutableMap.of(EntityDamageEvent.DamageModifier.BASE, damage)), new EnumMap(ImmutableMap.of(EntityDamageEvent.DamageModifier.BASE, Functions.constant(damage))));
+	    }
 	}
 }

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleFishingKnockback.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleFishingKnockback.java
@@ -100,10 +100,10 @@ public class ModuleFishingKnockback extends Module {
 		player.setVelocity(loc.subtract(rodder.getLocation()).toVector().normalize().multiply(0.4));
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked", "deprecation" })
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	private EntityDamageEvent makeEvent(Player rodder, Player player, double damage) {
 	    if (module().getBoolean("useEntityDamageEvent")) {
-	        return new EntityDamageEvent(player, EntityDamageEvent.DamageCause.ENTITY_ATTACK, damage);
+	        return new EntityDamageEvent(player, EntityDamageEvent.DamageCause.ENTITY_ATTACK, new EnumMap(ImmutableMap.of(EntityDamageEvent.DamageModifier.BASE, damage)), new EnumMap(ImmutableMap.of(EntityDamageEvent.DamageModifier.BASE, Functions.constant(damage))));
 	    } else {
 	        return new EntityDamageByEntityEvent(rodder, player, EntityDamageEvent.DamageCause.ENTITY_ATTACK, new EnumMap(ImmutableMap.of(EntityDamageEvent.DamageModifier.BASE, damage)), new EnumMap(ImmutableMap.of(EntityDamageEvent.DamageModifier.BASE, Functions.constant(damage))));
 	    }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -173,6 +173,9 @@ old-fishing-knockback:
   checkCancelled: false
   # This is the damage done by the fishing rod attack
   damage: 0.2
+  # Whether the EntityDamageEvent should be used instead of the EntityDamageByEntityEvent
+  # Set to true when using plugins like NCP that check range
+  useEntityDamageEvent: false
   
 projectile-knockback:
   # This adds knockback and/or damage to players when they get hit by snowballs, eggs & enderpearls


### PR DESCRIPTION
This may fix errors with some plugins like NCP as they might check the range between the players and therefor cancel the event.