### PR TITLE
Change DamageCause to projectile for fishing rods. Might also fix problems with NCP etc.

### DIFF
--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleFishingKnockback.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleFishingKnockback.java
@@ -104,12 +104,12 @@ public class ModuleFishingKnockback extends Module {
 		
 	    if (module().getBoolean("useEntityDamageEvent"))
 	        return new EntityDamageEvent(player,
-	        		EntityDamageEvent.DamageCause.ENTITY_ATTACK,
+	        		EntityDamageEvent.DamageCause.PROJECTILE,
 	        		new EnumMap(ImmutableMap.of(EntityDamageEvent.DamageModifier.BASE, damage)),
 	        		new EnumMap(ImmutableMap.of(EntityDamageEvent.DamageModifier.BASE, Functions.constant(damage))));
 	    else
 	        return new EntityDamageByEntityEvent(rodder, player,
-	        		EntityDamageEvent.DamageCause.ENTITY_ATTACK,
+	        		EntityDamageEvent.DamageCause.PROJECTILE,
 	        		new EnumMap(ImmutableMap.of(EntityDamageEvent.DamageModifier.BASE, damage)),
 	        		new EnumMap(ImmutableMap.of(EntityDamageEvent.DamageModifier.BASE, Functions.constant(damage))));
 	}


### PR DESCRIPTION
As projectiles are excluded from range-checks, this is another approach/an addition to https://github.com/gvlfm78/BukkitOldCombatMechanics/pull/59.