### PR TITLE
Added an option for the bow+sword combo

### DIFF
--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleSwordBlocking.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleSwordBlocking.java
@@ -37,6 +37,7 @@ public class ModuleSwordBlocking extends Module {
 
 	private int restoreDelay;
 	private String blockingDamageReduction;
+	private boolean bowSwordCombo;
 
 	private final Map<UUID, ItemStack> storedOffhandItems = new HashMap<>();
 	private final Map<UUID, BukkitRunnable> correspondingTasks = new HashMap<>();
@@ -51,6 +52,7 @@ public class ModuleSwordBlocking extends Module {
 		restoreDelay = module().getInt("restoreDelay", 40);
 		blockingDamageReduction = module().getString("blockingDamageReduction", "1");
 		blockingDamageReduction = blockingDamageReduction.replaceAll(" ", "");
+        bowSwordCombo = module().getBoolean("bowSwordCombo");
 	}
 
 	@EventHandler(priority = EventPriority.HIGHEST)
@@ -93,6 +95,8 @@ public class ModuleSwordBlocking extends Module {
 			if (!isHolding(item.getType(), "sword") || hasShield(p)) return;
 
 			PlayerInventory inv = p.getInventory();
+
+			if(inv.getItemInOffHand().getType().equals(Material.BOW) && bowSwordCombo == true) return;
 
 			storedOffhandItems.put(id, inv.getItemInOffHand());
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -149,7 +149,11 @@ sword-blocking:
   # If this is too slow players will have a shield in their hand well after they've stopped blocking
   # 20 ticks = 1 second
   restoreDelay: 40
-   
+  # Should having a bow in the off-hand and a sword in the main hand enable the bow combo?
+  # If this is enabled, when a player right-clicks with the sword+bow combo, the bow is drawn
+  # If this is disabled, when a player right-clicks with the sword+bow combo, he will block with the sword
+  bowSwordCombo: true
+
 old-golden-apples:
   # This is to change the behaviour / crafting of golden apples to how it was in pre-1.9
   enabled: true


### PR DESCRIPTION
I tried adding the following feature: a configurable option to disable sword blocking when the player has a bow in his off-hand (enabled by default)
The sword in main hand + bow in the off-hand combo is a popular one for PvP, but if you enable the sword blocking, the bow becomes useless, because the it gets replaced with the shield when you right-click.
If the bowSword combo is enabled and the player holds a bow in his off-hand, sword blocking won't happen. Instead, the player draws the bow.

_Note: This is my first time coding in Java. If I made a messy code, please criticize 😃 _