### PR TITLE
Fix the collision module when another plugin modifies the scoreboard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,14 @@
 			<artifactId>bstats-bukkit</artifactId>
 			<version>1.2</version>
 		</dependency>
-	</dependencies>
+		<!--Shaded in by bukkit -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>4.1.21.Final</version>
+			<scope>provided</scope>
+        </dependency>
+    </dependencies>
 	<build>
 		<defaultGoal>clean package</defaultGoal>
 		<finalName>${project.artifactId}</finalName>

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/OCMMain.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/OCMMain.java
@@ -6,13 +6,12 @@ import gvlfm78.plugin.OldCombatMechanics.updater.ModuleUpdateChecker;
 import gvlfm78.plugin.OldCombatMechanics.utilities.Config;
 import gvlfm78.plugin.OldCombatMechanics.utilities.Messenger;
 import org.bstats.bukkit.Metrics;
-import org.bukkit.Bukkit;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scoreboard.Scoreboard;
-import org.bukkit.scoreboard.Team;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -21,6 +20,7 @@ public class OCMMain extends JavaPlugin {
     private static OCMMain INSTANCE;
     private Logger logger = getLogger();
     private OCMConfigHandler CH = new OCMConfigHandler(this);
+    private List<Runnable> disableListeners = new ArrayList<>();
 
     public static OCMMain getInstance(){
         return INSTANCE;
@@ -77,6 +77,8 @@ public class OCMMain extends JavaPlugin {
 
         PluginDescriptionFile pdfFile = this.getDescription();
 
+        disableListeners.forEach(Runnable::run);
+
         //if (task != null) task.cancel();
 
         // Logging to console the disabling of OCM
@@ -121,5 +123,14 @@ public class OCMMain extends JavaPlugin {
 
     public boolean doesConfigExist(){
         return CH.doesConfigExist();
+    }
+
+    /**
+     * Registers a runnable to run when the plugin gets disabled.
+     *
+     * @param action the {@link Runnable} to run when the plugin gets disabled
+     */
+    public void addDisableListener(Runnable action) {
+        disableListeners.add(action);
     }
 }

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModulePlayerCollisions.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModulePlayerCollisions.java
@@ -9,6 +9,7 @@ import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.TeamUtils;
 import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.type.ClassType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
@@ -22,8 +23,21 @@ public class ModulePlayerCollisions extends Module {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerLogin(PlayerJoinEvent e) {
-        TeamUtils.sendTeamPacket(e.getPlayer());
+        if (isEnabled(e.getPlayer().getWorld())) {
+            TeamUtils.sendTeamPacket(e.getPlayer());
+        }
+
+        // always attach the listener, it checks internally
         PacketManager.getInstance().addListener(collisionPacketListener, e.getPlayer());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerChangeWorld(PlayerChangedWorldEvent e) {
+        if (isEnabled(e.getPlayer().getWorld())) {
+            TeamUtils.sendTeamPacket(e.getPlayer());
+        } else {
+            TeamUtils.sendTeamRemovePacket(e.getPlayer());
+        }
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
@@ -31,14 +45,18 @@ public class ModulePlayerCollisions extends Module {
         TeamUtils.getSecurePlayers().remove(e.getPlayer());
     }
 
-    private static class CollisionPacketListener extends PacketAdapter {
+    private class CollisionPacketListener extends PacketAdapter {
 
-        private static final Class<?> targetClass = Reflector
+        private final Class<?> targetClass = Reflector
                 .getClass(ClassType.NMS, "PacketPlayOutScoreboardTeam");
 
         @Override
         public void onPacketSend(PacketEvent packetEvent) {
             if (packetEvent.getPacket().getPacketClass() != targetClass) {
+                return;
+            }
+
+            if (!isEnabled(packetEvent.getPlayer().getWorld())) {
                 return;
             }
 

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModulePlayerCollisions.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModulePlayerCollisions.java
@@ -1,7 +1,12 @@
 package gvlfm78.plugin.OldCombatMechanics.module;
 
 import gvlfm78.plugin.OldCombatMechanics.OCMMain;
+import gvlfm78.plugin.OldCombatMechanics.utilities.packet.PacketAdapter;
+import gvlfm78.plugin.OldCombatMechanics.utilities.packet.PacketEvent;
+import gvlfm78.plugin.OldCombatMechanics.utilities.packet.PacketManager;
+import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.Reflector;
 import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.TeamUtils;
+import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.type.ClassType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -9,18 +14,40 @@ import org.bukkit.event.player.PlayerQuitEvent;
 
 public class ModulePlayerCollisions extends Module {
 
-    public ModulePlayerCollisions(OCMMain plugin){
+    private CollisionPacketListener collisionPacketListener = new CollisionPacketListener();
+
+    public ModulePlayerCollisions(OCMMain plugin) {
         super(plugin, "disable-player-collisions");
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
-    public void onPlayerLogin(PlayerJoinEvent e){
+    public void onPlayerLogin(PlayerJoinEvent e) {
         TeamUtils.sendTeamPacket(e.getPlayer());
+        PacketManager.getInstance().addListener(collisionPacketListener, e.getPlayer());
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
-    public void onPlayerQuit(PlayerQuitEvent e){
+    public void onPlayerQuit(PlayerQuitEvent e) {
         TeamUtils.getSecurePlayers().remove(e.getPlayer());
     }
 
+    private static class CollisionPacketListener extends PacketAdapter {
+
+        private static final Class<?> targetClass = Reflector
+                .getClass(ClassType.NMS, "PacketPlayOutScoreboardTeam");
+
+        @Override
+        public void onPacketSend(PacketEvent packetEvent) {
+            if (packetEvent.getPacket().getPacketClass() != targetClass) {
+                return;
+            }
+
+            try {
+                // this is very prone to changes as it just *gets the field by name*. But not in my code.
+                TeamUtils.changePacketCollisionType(packetEvent.getPacket().getNMSPacket());
+            } catch (ReflectiveOperationException e) {
+                throw new RuntimeException("An error occurred setting the collision rule", e);
+            }
+        }
+    }
 }

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/Packet.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/Packet.java
@@ -1,0 +1,145 @@
+package gvlfm78.plugin.OldCombatMechanics.utilities.packet;
+
+import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.Reflector;
+import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.type.ClassType;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Objects;
+
+
+/**
+ * A class which represents a packet.
+ *
+ * @see #create(String)
+ */
+public class Packet {
+
+    /**
+     * The net.minecraft.server.Packet class
+     * <p>
+     * Will be null if not found
+     */
+    private static final Class<?> NMS_PACKET_CLASS = Reflector.getClass(ClassType.NMS, "Packet");
+
+    private Class<?> packetClass;
+    private Object rawPacket;
+
+    /**
+     * Creates a packet
+     *
+     * @param packetClass The class of the packet
+     * @throws NoSuchMethodException     if the packet has no default constructor
+     * @throws IllegalAccessException    if I have no rights to use reflection
+     * @throws InvocationTargetException if the packet constructor threw an
+     *                                   error
+     * @throws InstantiationException    if an error occurred finding something to
+     *                                   instantiate
+     */
+    private Packet(Class<?> packetClass) throws NoSuchMethodException,
+            IllegalAccessException,
+            InvocationTargetException,
+            InstantiationException {
+        this(packetClass.getConstructor().newInstance());
+    }
+
+    /**
+     * @param packet The raw NMS packet
+     */
+    private Packet(Object packet) {
+        this.rawPacket = packet;
+        this.packetClass = packet.getClass();
+    }
+
+    /**
+     * Creates a new {@link Packet}
+     *
+     * @param name the packet class name. Can be in two forms: "PacketXXX" or
+     *             "XXX" (e.g. "PacketPlayOutPosition" or "PlayOutPosition"
+     * @return a new Packet, or null if something went wrong
+     * @throws IllegalArgumentException if it couldn't find the specified packet
+     *                                  class
+     * @throws RuntimeException         wrapping any of the exceptions occurring due to
+     *                                  Reflection (i.e. {@link NoSuchMethodException},
+     *                                  {@link IllegalAccessException},
+     *                                  {@link InvocationTargetException},
+     *                                  {@link InstantiationException})
+     */
+    @SuppressWarnings({"WeakerAccess", "unused"})
+    public static Packet create(String name) {
+        String packetName = name;
+        if (!packetName.startsWith("Packet")) {
+            packetName = "Packet" + packetName;
+        }
+
+        Class<?> packetClass = Reflector.getClass(ClassType.NMS, packetName);
+        Objects.requireNonNull(packetClass, "packetClass can not be null!");
+
+        try {
+            return new Packet(packetClass);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException
+                e) {
+            String message = "Failed to create packet!"
+                    + String.format("Name: %s, Replaced, %s Class: %s", name, packetName, packetClass);
+            throw new RuntimeException(message, e);
+        }
+    }
+
+    /**
+     * Creates a new Packet
+     *
+     * @param nmsPacket The NMS packet object
+     * @return The wrapping Packet
+     * @throws IllegalStateException    if it couldn't find the NMS base class
+     *                                  "Packet" (You are screwed)
+     * @throws IllegalArgumentException if it isn't a packet.
+     * @throws RuntimeException         if <i>some</i> error occurred instantiating the
+     *                                  {@link Packet}
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static Packet createFromNMSPacket(Object nmsPacket) {
+        Objects.requireNonNull(nmsPacket, "nmsPacket can not be null");
+
+        if (NMS_PACKET_CLASS == null) {
+            throw new IllegalStateException("Could not find packet class! Therefore this class is broken.");
+        }
+
+        if (!Reflector.inheritsFrom(nmsPacket.getClass(), NMS_PACKET_CLASS)) {
+            throw new IllegalArgumentException("You must pass a 'Packet' object!");
+        }
+
+        try {
+            return new Packet(nmsPacket);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create packet!", e);
+        }
+    }
+
+    /**
+     * @return the NMS packet
+     */
+    @SuppressWarnings("WeakerAccess")
+    public Object getNMSPacket() {
+        return rawPacket;
+    }
+
+    /**
+     * Sends this packet to the given players
+     *
+     * @param players the players to send it to
+     */
+    @SuppressWarnings("unused")
+    public void send(Player... players) {
+        for (Player player : players) {
+            PacketSender.getInstance().sendPacket(this, player);
+        }
+    }
+
+    /**
+     * @return the packet's class
+     */
+    @SuppressWarnings("unused")
+    public Class<?> getPacketClass() {
+        return packetClass;
+    }
+}

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketAdapter.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketAdapter.java
@@ -1,0 +1,17 @@
+package gvlfm78.plugin.OldCombatMechanics.utilities.packet;
+
+/**
+ * Skeleton implementation of {@link PacketListener}.
+ */
+public class PacketAdapter implements PacketListener {
+
+    @Override
+    public void onPacketReceived(PacketEvent packetEvent) {
+
+    }
+
+    @Override
+    public void onPacketSend(PacketEvent packetEvent) {
+
+    }
+}

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketEvent.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketEvent.java
@@ -1,0 +1,115 @@
+package gvlfm78.plugin.OldCombatMechanics.utilities.packet;
+
+import org.bukkit.entity.Player;
+
+/**
+ * A packet event
+ */
+public class PacketEvent {
+
+    private Packet packet;
+    private Player player;
+    private boolean cancelled;
+    private ConnectionDirection direction;
+
+    /**
+     * @param packet The packet
+     * @param cancelled Whether the event is cancelled
+     * @param direction The direction the packet is travelling
+     * @param player The involved Player
+     *
+     * @throws IllegalStateException    if it couldn't find the NMS base class
+     *                                  "Packet" (You are screwed)
+     * @throws IllegalArgumentException if 'object' isn't a packet.
+     */
+    @SuppressWarnings("WeakerAccess")
+    protected PacketEvent(Object packet, boolean cancelled, ConnectionDirection direction, Player player) {
+        this.packet = Packet.createFromNMSPacket(packet);
+        this.cancelled = cancelled;
+        this.direction = direction;
+        this.player = player;
+    }
+
+    /**
+     * This is not cancelled
+     *
+     * @param packet The packet
+     * @param direction The direction the packet is travelling
+     * @param player The involved Player
+     *
+     * @see #PacketEvent(Object, boolean, ConnectionDirection, Player)
+     */
+    @SuppressWarnings("WeakerAccess")
+    protected PacketEvent(Object packet, ConnectionDirection direction, Player player) {
+        this(packet, false, direction, player);
+    }
+
+    /**
+     * Returns the packet
+     *
+     * @return The Packet
+     */
+    @SuppressWarnings("unused")
+    public Packet getPacket() {
+        return packet;
+    }
+
+    /**
+     * Sets the new packet
+     *
+     * @param packet The new packet
+     */
+    @SuppressWarnings("unused")
+    public void setPacket(Packet packet) {
+        this.packet = packet;
+    }
+
+    /**
+     * Checks if the event is cancelled
+     *
+     * @return True if the event is cancelled
+     */
+    @SuppressWarnings("WeakerAccess")
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    /**
+     * Sets the events cancelled status.
+     *
+     * @param cancelled if true, the event will be cancelled.
+     */
+    @SuppressWarnings({"unused", "SameParameterValue"})
+    public void setCancelled(boolean cancelled) {
+        // should even be atomic
+        this.cancelled = cancelled;
+    }
+
+    /**
+     * Returns the connection direction
+     *
+     * @return The Direction the packet was travelling
+     */
+    @SuppressWarnings("unused")
+    public ConnectionDirection getDirection() {
+        return direction;
+    }
+
+    /**
+     * Returns the involved Player
+     *
+     * @return The player that is involved.
+     */
+    @SuppressWarnings("unused")
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * The direction the packet was travelling
+     */
+    public enum ConnectionDirection {
+        TO_CLIENT,
+        TO_SERVER
+    }
+}

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketInjector.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketInjector.java
@@ -1,0 +1,172 @@
+package gvlfm78.plugin.OldCombatMechanics.utilities.packet;
+
+import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.Reflector;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import org.bukkit.entity.Player;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A simple packet injector, to modify the packets sent and received
+ */
+class PacketInjector extends ChannelDuplexHandler {
+
+    private static final Logger LOGGER = Logger.getLogger("PacketInjector");
+
+    private boolean isClosed;
+    private Channel channel;
+    private List<PacketListener> packetListeners = new ArrayList<>();
+    private WeakReference<Player> playerWeakReference;
+
+    /**
+     * Must be detached manually!
+     *
+     * @param player The player to attach into
+     */
+    PacketInjector(Player player) {
+        try {
+            attach(player);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        playerWeakReference = new WeakReference<>(player);
+    }
+
+    /**
+     * Attaches to a player
+     *
+     * @param player The player to attach to
+     */
+    private void attach(Player player) throws Exception {
+
+        // Lengthy way of doing: ( (CraftPlayer) handle
+        // ).getHandle().playerConnection.networkManager.channel
+        Object playerConnection = PacketSender.getInstance().getConnection(player);
+
+
+        Object manager = Reflector.getFieldValue(playerConnection, "networkManager");
+
+        channel = (Channel) Reflector.getFieldValue(manager, "channel");
+
+        // remove old listener, if it wasn't properly cleared up
+        if (channel.pipeline().get("ocm_handler") != null) {
+            // remove old
+            channel.pipeline().remove("ocm_handler");
+        }
+
+        channel.pipeline().addBefore("packet_handler", "ocm_handler", this);
+    }
+
+    /**
+     * Removes this handler
+     */
+    void detach() {
+        if (isClosed || !channel.isOpen()) {
+            return;
+        }
+        isClosed = true;
+        channel.eventLoop().submit(() -> channel.pipeline().remove(this));
+
+        // clear references. Probably not needed, but I am not sure about the
+        // channel.
+        playerWeakReference.clear();
+        packetListeners.clear();
+        channel = null;
+    }
+
+    /**
+     * Checks if this handler is closed
+     *
+     * @return True if the handler is closed
+     */
+    private boolean isClosed() {
+        return isClosed;
+    }
+
+    /**
+     * Adds a {@link PacketListener}
+     *
+     * @param packetListener The {@link PacketListener} to add
+     * @throws IllegalStateException if the channel is already closed
+     */
+    void addPacketListener(PacketListener packetListener) {
+        Objects.requireNonNull(packetListener, "packetListener can not be null");
+        if (isClosed()) {
+            throw new IllegalStateException("Channel already closed. Adding of listener invalid");
+        }
+        packetListeners.add(packetListener);
+    }
+
+    /**
+     * Removes a {@link PacketListener}
+     *
+     * @param packetListener The {@link PacketListener} to remove
+     */
+    void removePacketListener(PacketListener packetListener) {
+        packetListeners.remove(packetListener);
+    }
+
+    /**
+     * Returns the amount of listeners
+     *
+     * @return The amount of listeners
+     */
+    int getListenerAmount() {
+        return packetListeners.size();
+    }
+
+    @Override
+    public void write(ChannelHandlerContext channelHandlerContext, Object packet, ChannelPromise channelPromise)
+            throws Exception {
+        PacketEvent event = new PacketEvent(
+                packet,
+                PacketEvent.ConnectionDirection.TO_CLIENT,
+                playerWeakReference.get()
+        );
+
+        for (PacketListener packetListener : packetListeners) {
+            try {
+                packetListener.onPacketSend(event);
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING,
+                        "Error in a Packet Listener (send). Nag the author of that plugin!", e);
+            }
+        }
+
+        // let it through
+        if (!event.isCancelled()) {
+            super.write(channelHandlerContext, packet, channelPromise);
+        }
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext channelHandlerContext, Object packet) throws Exception {
+        PacketEvent event = new PacketEvent(
+                packet,
+                PacketEvent.ConnectionDirection.TO_SERVER,
+                playerWeakReference.get()
+        );
+
+        for (PacketListener packetListener : packetListeners) {
+            try {
+                packetListener.onPacketReceived(event);
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING,
+                        "Error in a Packet Listener (receive). Nag the author of that plugin!", e);
+            }
+        }
+
+        // let it through
+        if (!event.isCancelled()) {
+            super.channelRead(channelHandlerContext, packet);
+        }
+    }
+}

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketListener.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketListener.java
@@ -1,0 +1,21 @@
+package gvlfm78.plugin.OldCombatMechanics.utilities.packet;
+
+/**
+ * Listens for a Packet
+ */
+public interface PacketListener {
+
+    /**
+     * Called when a packet is received
+     *
+     * @param packetEvent The {@link PacketEvent}
+     */
+    void onPacketReceived(PacketEvent packetEvent);
+
+    /**
+     * Called when a packet is send
+     *
+     * @param packetEvent The {@link PacketEvent}
+     */
+    void onPacketSend(PacketEvent packetEvent);
+}

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketManager.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketManager.java
@@ -1,0 +1,154 @@
+package gvlfm78.plugin.OldCombatMechanics.utilities.packet;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+import gvlfm78.plugin.OldCombatMechanics.OCMMain;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Manages PacketListeners and stuff
+ * <p>
+ * This Manager removes the listeners when the Player leaves. You do not need to
+ * keep track of that!
+ */
+public class PacketManager implements Listener {
+
+    private static PacketManager instance;
+
+    private final Map<UUID, PacketInjector> injectorMap = new HashMap<>();
+
+    {
+        OCMMain.getInstance().addDisableListener(() -> {
+            removeAll();
+            instance = null;
+        });
+    }
+
+    /**
+     * Instantiates a new PacketManager
+     *
+     * @param plugin The plugin to instantiate it as
+     */
+    private PacketManager(Plugin plugin) {
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    /**
+     * Adds a packet listener
+     *
+     * @param listener The {@link PacketListener} to add
+     * @param player The Player to listen for
+     *
+     * @throws NullPointerException if any parameter is null
+     */
+    @SuppressWarnings("unused")
+    public void addListener(PacketListener listener, Player player) {
+        Objects.requireNonNull(listener, "listener can not be null");
+        Objects.requireNonNull(player, "player can not be null");
+
+        // no modifications during checks or the result may be wrong! (it
+        // changes depending on the current state)
+        synchronized (injectorMap) {
+            if (injectorMap.containsKey(player.getUniqueId())) {
+                injectorMap.get(player.getUniqueId()).addPacketListener(listener);
+            }
+            else {
+                PacketInjector injector = new PacketInjector(player);
+                injector.addPacketListener(listener);
+                injectorMap.put(player.getUniqueId(), injector);
+            }
+        }
+    }
+
+    /**
+     * Removes the Listener for a player
+     *
+     * @param listener The listener to remove
+     * @param player The player to remove it for
+     *
+     * @throws NullPointerException if any parameter is null
+     */
+    @SuppressWarnings("unused")
+    public void removeListener(PacketListener listener, Player player) {
+        Objects.requireNonNull(listener, "listener can not be null");
+        Objects.requireNonNull(player, "player can not be null");
+
+        // no modifications during checks or the result may be wrong! (it
+        // changes depending on the current state)
+        synchronized (injectorMap) {
+            if (!injectorMap.containsKey(player.getUniqueId())) {
+                return;
+            }
+            PacketInjector injector = injectorMap.get(player.getUniqueId());
+            injector.removePacketListener(listener);
+            if (injector.getListenerAmount() < 1) {
+                injector.detach();
+                injectorMap.remove(player.getUniqueId());
+            }
+        }
+    }
+
+    /**
+     * Removes <b>all</b> listeners from a player
+     *
+     * @param uuid The {@link UUID} of the Player to remove all listeners for
+     *
+     * @throws NullPointerException if uuid is null
+     */
+    @SuppressWarnings("WeakerAccess")
+    public void removeAllListeners(UUID uuid) {
+        Objects.requireNonNull(uuid, "uuid can not be null");
+
+        // no modifications during checks or the result may be wrong! (it
+        // changes depending on the current state)
+        synchronized (injectorMap) {
+            if (injectorMap.containsKey(uuid)) {
+                injectorMap.get(uuid).detach();
+                injectorMap.remove(uuid);
+            }
+        }
+    }
+
+    /**
+     * <i>Removes <b>ALL</b> listeners</i>
+     * <p>
+     * Use with caution or not at all.
+     */
+    private void removeAll() {
+        synchronized (injectorMap) {
+            // clone to avoid concurrent modification
+            Set<UUID> keys = new HashSet<>(injectorMap.keySet());
+            keys.forEach(this::removeAllListeners);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onLeave(PlayerQuitEvent event) {
+        // clean up
+        removeAllListeners(event.getPlayer().getUniqueId());
+    }
+
+    /**
+     * Returns the Manager instance
+     *
+     * @return An instance of the PacketManager
+     */
+    @SuppressWarnings("unused")
+    public static synchronized PacketManager getInstance() {
+        if (instance == null) {
+            instance = new PacketManager(OCMMain.getInstance());
+        }
+        return instance;
+    }
+}

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketSender.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketSender.java
@@ -1,0 +1,71 @@
+package gvlfm78.plugin.OldCombatMechanics.utilities.packet;
+
+import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.Reflector;
+import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.type.ClassType;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+/**
+ * A Packet sender
+ */
+class PacketSender {
+
+    private static final Class<?> CRAFT_PLAYER =
+            Objects.requireNonNull(Reflector.getClass(ClassType.CRAFTBUKKIT, "entity.CraftPlayer"));
+    private static final Class<?> PLAYER_CONNECTION =
+            Objects.requireNonNull(Reflector.getClass(ClassType.NMS, "PlayerConnection"));
+    private static final Class<?> ENTITY_PLAYER =
+            Objects.requireNonNull(Reflector.getClass(ClassType.NMS, "EntityPlayer"));
+
+
+    private static final Method GET_HANDLE = Reflector.getMethod(
+            CRAFT_PLAYER, "getHandle"
+    );
+    private static final Method SEND_PACKET = Reflector.getMethod(
+            PLAYER_CONNECTION, "sendPacket"
+    );
+    private static final Field PLAYER_CONNECTION_FIELD = Reflector.getField(
+            ENTITY_PLAYER, "playerConnection"
+    );
+
+    private static final PacketSender instance = new PacketSender();
+
+    private PacketSender() {
+    }
+
+    /**
+     * Sends a packet to a Player
+     *
+     * @param packet The {@link Packet} to send
+     * @param player The Player to send it to
+     */
+    void sendPacket(Packet packet, Player player) {
+        sendPacket(packet.getNMSPacket(), getConnection(player));
+    }
+
+    /**
+     * @return The Instance of the PacketSender
+     */
+    static PacketSender getInstance() {
+        return instance;
+    }
+
+    private void sendPacket(Object nmsPacket, Object playerConnection) {
+        Reflector.invokeMethod(SEND_PACKET, playerConnection, nmsPacket);
+    }
+
+    /**
+     * Returns the Player's PlayerConnection
+     *
+     * @param player The Player to get the Connection for
+     * @return The Player's connection
+     */
+    Object getConnection(Player player) {
+        Object handle = Reflector.invokeMethod(GET_HANDLE, player);
+
+        return Reflector.getFieldValue(PLAYER_CONNECTION_FIELD, handle);
+    }
+}

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/reflection/Reflector.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/reflection/Reflector.java
@@ -1,5 +1,6 @@
 package gvlfm78.plugin.OldCombatMechanics.utilities.reflection;
 
+import gvlfm78.plugin.OldCombatMechanics.utilities.packet.Packet;
 import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.type.ClassType;
 import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.type.PacketType;
 import org.bukkit.Bukkit;
@@ -19,8 +20,8 @@ public class Reflector {
     private static Method PLAYER_HANDLE;
     private static String version = "";
 
-    static{
-        try{
+    static {
+        try {
             version = Bukkit.getServer().getClass().getName().split("\\.")[3];
 
             Class<?> CRAFT_PLAYER = getClass(ClassType.CRAFTBUKKIT, "entity.CraftPlayer");
@@ -28,88 +29,119 @@ public class Reflector {
 
             PLAYER_HANDLE = getMethod(CRAFT_PLAYER, "getHandle");
 
-        } catch(Exception e){
+        } catch (Exception e) {
             System.err.println("Failed to load Reflector");
             e.printStackTrace();
         }
 
     }
 
-    public static String getVersion(){
+    public static String getVersion() {
         return version;
     }
 
-    public static Class<?> getClass(ClassType type, String name){
-        try{
+    public static Class<?> getClass(ClassType type, String name) {
+        try {
             return Class.forName(String.format("%s.%s.%s", type.getPackage(), version, name));
-        } catch(ClassNotFoundException e){
+        } catch (ClassNotFoundException e) {
             e.printStackTrace();
             return null;
         }
     }
 
 
-    public static Method getMethod(Class<?> clazz, String name){
+    public static Method getMethod(Class<?> clazz, String name) {
         return Arrays.stream(clazz.getMethods())
                 .filter(method -> method.getName().equals(name))
                 .findFirst()
                 .orElse(null);
     }
 
-    public static void invokeMethod(Object object, String name, Object... params) throws InvocationTargetException, IllegalAccessException{
+    public static void invokeMethod(Object object, String name, Object... params) throws InvocationTargetException, IllegalAccessException {
         getMethod((object.getClass()), name).invoke(object, params);
     }
 
-    public static Field getField(Class<?> clazz, String fieldName) throws Exception{
-        return clazz.getDeclaredField(fieldName);
+    public static <T> T invokeMethod(Method method, Object handle, Object... params) {
+        try {
+            @SuppressWarnings("unchecked")
+            T t = (T) method.invoke(handle, params);
+            return t;
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
     }
 
-    public static Field getInaccessibleField(Class<?> clazz, String fieldName) throws Exception{
+    public static Field getField(Class<?> clazz, String fieldName) {
+        try {
+            return clazz.getDeclaredField(fieldName);
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static Field getInaccessibleField(Class<?> clazz, String fieldName) throws Exception {
         Field field = getField(clazz, fieldName);
         field.setAccessible(true);
         return field;
     }
 
-    public static Object getFieldValue(Object object, String fieldName) throws Exception{
+    public static Object getFieldValue(Object object, String fieldName) throws Exception {
         return getInaccessibleField(object.getClass(), fieldName).get(object);
     }
 
-    public static void setFieldValue(Object object, String fieldName, Object value) throws Exception{
+    public static Object getFieldValue(Field field, Object handle) {
+        field.setAccessible(true);
+        try {
+            return field.get(handle);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void setFieldValue(Object object, String fieldName, Object value) throws Exception {
         getInaccessibleField(object.getClass(), fieldName).set(object, value);
     }
 
-    public static Constructor<?> getConstructor(Class<?> clazz, int numParams){
+    public static Constructor<?> getConstructor(Class<?> clazz, int numParams) {
         return Arrays.stream(clazz.getConstructors())
                 .filter(constructor -> constructor.getParameterCount() == numParams)
                 .findFirst()
                 .orElse(null);
     }
 
-
-    private static Object getPlayerHandler(Player player){
-        try{
-            return PLAYER_HANDLE.invoke(player);
-        } catch(InvocationTargetException | IllegalAccessException e){
-            e.printStackTrace();
-            return null;
+    /**
+     * Checks if a given class <i>somehow</i> inherits from another class
+     *
+     * @param toCheck The class to check
+     * @param inheritedClass The inherited class, it should have
+     *
+     * @return True if {@code toCheck} somehow inherits from
+     * {@code inheritedClass}
+     */
+    public static boolean inheritsFrom(Class<?> toCheck, Class<?> inheritedClass) {
+        if (inheritedClass.isAssignableFrom(toCheck)) {
+            return true;
         }
+
+        for (Class<?> implementedInterface : toCheck.getInterfaces()) {
+            if (inheritsFrom(implementedInterface, inheritedClass)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
+
     public static class Packets {
-        public static Class<?> getPacket(PacketType type, String name){
+        public static Class<?> getPacket(PacketType type, String name) {
             return Reflector.getClass(ClassType.NMS, "Packet" + type.prefix + name);
         }
 
-        public static void sendPacket(Player player, Object packet){
-            try{
-                Object nmsPlayer = getPlayerHandler(player);
-                assert nmsPlayer != null;
-
-                Object con = getFieldValue(nmsPlayer, "playerConnection");
-                assert con != null;
-
-                invokeMethod(con, "sendPacket", packet);
-            } catch(Exception e){
+        public static void sendPacket(Player player, Object packet) {
+            try {
+                Packet.createFromNMSPacket(packet).send(player);
+            } catch (Exception e) {
                 e.printStackTrace();
             }
         }

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/reflection/TeamUtils.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/reflection/TeamUtils.java
@@ -25,8 +25,8 @@ public class TeamUtils {
     private static Field collisionRuleField;
     private static Field playersField;
 
-    static{
-        try{
+    static {
+        try {
             Class<?> packetTeamClass = Reflector.Packets.getPacket(PacketType.PlayOut, "ScoreboardTeam");
             packetScoreboardTeamConstructor = Reflector.getConstructor(packetTeamClass, 0);
 
@@ -34,17 +34,17 @@ public class TeamUtils {
             modeField = Reflector.getInaccessibleField(packetTeamClass, "i");
             collisionRuleField = Reflector.getInaccessibleField(packetTeamClass, "f");
             playersField = Reflector.getInaccessibleField(packetTeamClass, "h");
-        } catch(Exception ex){
+        } catch (Exception ex) {
             ex.printStackTrace();
         }
     }
 
-    public static synchronized void sendTeamPacket(Player player){
-        if(getSecurePlayers().contains(player)){
+    public static synchronized void sendTeamPacket(Player player) {
+        if (getSecurePlayers().contains(player)) {
             return;
         }
 
-        try{
+        try {
             Object packetTeamObject = packetScoreboardTeamConstructor.newInstance();
 
             nameField.set(packetTeamObject, UUID.randomUUID().toString().substring(0, 15));
@@ -54,16 +54,22 @@ public class TeamUtils {
             changePacketCollisionType(packetTeamObject);
 
             Reflector.Packets.sendPacket(player, packetTeamObject);
-        } catch(Exception ex){
+        } catch (Exception ex) {
             ex.printStackTrace();
         }
     }
 
-    private static void changePacketCollisionType(Object packetTeamObject) throws Exception{
+    /**
+     * Sets the collision rule to never.
+     *
+     * @param packetTeamObject the packet to set it on
+     * @throws ReflectiveOperationException if an error occurs
+     */
+    public static void changePacketCollisionType(Object packetTeamObject) throws ReflectiveOperationException {
         collisionRuleField.set(packetTeamObject, "never");
     }
 
-    public static List<Player> getSecurePlayers(){
+    public static List<Player> getSecurePlayers() {
         return securePlayers;
     }
 }

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/reflection/TeamUtils.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/reflection/TeamUtils.java
@@ -5,7 +5,12 @@ import org.bukkit.entity.Player;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.WeakHashMap;
 
 /**
  * From <a href="https://www.spigotmc.org/resources/1-9-anti-collision.28770/">1.9 anti-collision plugin by Mentrixx</a>
@@ -49,7 +54,7 @@ public class TeamUtils {
             teamNameMap.put(player, teamName);
 
             nameField.set(packetTeamObject, teamName);
-            modeField.set(packetTeamObject, 0);
+            modeField.set(packetTeamObject, TeamAction.CREATE.getMinecraftId());
             playersField.set(packetTeamObject, Collections.singletonList(player.getName()));
 
             changePacketCollisionType(packetTeamObject);
@@ -77,7 +82,7 @@ public class TeamUtils {
             Object packetTeamObject = packetScoreboardTeamConstructor.newInstance();
 
             nameField.set(packetTeamObject, teamName);
-            modeField.set(packetTeamObject, 1);
+            modeField.set(packetTeamObject, TeamAction.DISBAND.getMinecraftId());
 
             Reflector.Packets.sendPacket(player, packetTeamObject);
 
@@ -99,5 +104,23 @@ public class TeamUtils {
 
     public static List<Player> getSecurePlayers() {
         return securePlayers;
+    }
+
+    /**
+     * The different actions a {@code PacketPlayOutScoreboardTeam} packet can represent.
+     */
+    private enum TeamAction {
+        CREATE(0),
+        DISBAND(1);
+
+        private int minecraftId;
+
+        TeamAction(int minecraftId) {
+            this.minecraftId = minecraftId;
+        }
+
+        public int getMinecraftId() {
+            return minecraftId;
+        }
     }
 }


### PR DESCRIPTION
### Function
Always disables collision on all collision packets the server sends.

### Note
The code is mostly taken from an old plugin of mine, so the javadoc may not be ideal at parts. I also had a `ReflectionUtil` that had major differences to the `Reflector` currently in the Plugin, so I got rid of mine and tried to convert it.

I also logically had some abstractions or models for Packets, so there are now one or two methods that duplicate already existing functionality. I kept them small, but I didn't want to redo the existing reflection usage in your code as I was afraid to introduce some new interesting bugs.

### Motivation
Trying to fix #173, which likely was caused by another plugin sending its own scoreboard packets. As this just rewrites every scoreboard team packet the server sends it should restore functionality.