### PR TITLE
Fix #195 -- Playerconnection subclasses erroring

### DIFF
--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/reflection/Reflector.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/reflection/Reflector.java
@@ -86,8 +86,33 @@ public class Reflector {
     }
 
     public static Object getFieldValue(Object object, String fieldName) throws Exception{
-        return getInaccessibleField(object.getClass(), fieldName).get(object);
+        return findFieldWithinHierarchy(object, fieldName).get(object);
     }
+
+    /**
+     * Finds a field within the class or any superclasses (but ignored interfaces).
+     *
+     * @param object    the handle and start for the search
+     * @param fieldName the name of the field
+     * @return the found field
+     * @throws NoSuchFieldException if the field couldn't be found
+     */
+    private static Field findFieldWithinHierarchy(Object object, String fieldName) throws NoSuchFieldException{
+        Class<?> clazz = object.getClass();
+
+        while(clazz != null){
+            for(Field field : clazz.getDeclaredFields()){
+                if(field.getName().equals(fieldName)){
+                    field.setAccessible(true);
+                    return field;
+                }
+            }
+            clazz = clazz.getSuperclass();
+        }
+
+        throw new NoSuchFieldException(fieldName);
+    }
+
 
     public static Object getFieldValue(Field field, Object handle){
         field.setAccessible(true);


### PR DESCRIPTION
## Motivation
If another plugin overwrote the PlayerConnection class, getting the networkManager requires also looking through the superclasses. This patch makes the getValue method (which was used for this) also look through all superclasses, in order to find the field.


## Possible problems
Whether this change should be applied more generally would need some more thought as to where it is used. Maybe other code could also benefit from this slightly expanded search, but it depends on where exactly the reflection method is used. As everything works at the moment, changing this could probably be evaluated at a later date, when something with reflection breaks again.

Or you do it now, but then you need to check all different uses of the method…

## Resolves
#195, incompatibility with `iDisguise`

### PS
This is an exact copy of #199 (if I haven't made a mistake). I just adjusted my history after the complete history of the main repo was rewritten out of nowhere…