### PR TITLE
Fix #205, a NPE in the sword blocking module

### DIFF
--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleSwordBlocking.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleSwordBlocking.java
@@ -255,7 +255,9 @@ public class ModuleSwordBlocking extends Module {
 
     private void postponeRestoring(Player p){
         UUID id = p.getUniqueId();
-        correspondingTasks.get(id).cancelAll();
+        Optional.ofNullable(correspondingTasks.get(id))
+                .ifPresent(RunnableSeries::cancelAll);
+
         correspondingTasks.remove(id);
         scheduleRestore(p);
     }


### PR DESCRIPTION
## Motivation
If the user switched the slot while blocking, the task was removed but another called method assumed it is always present. This just makes it check before cancelling it (again).

## Closes
#205 

## See also
https://github.com/gvlfm78/BukkitOldCombatMechanics/issues/205#issuecomment-408107454