### PR TITLE
Make the PacketInjector a bit more robust to sudden connection loss and allow it to work after a reload

### DIFF
--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/OCMMain.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/OCMMain.java
@@ -152,9 +152,9 @@ public class OCMMain extends JavaPlugin {
         disableListeners.add(action);
     }
     /**
-     * Registers a runnable to run when the plugin gets disabled.
+     * Registers a runnable to run when the plugin gets enabled.
      *
-     * @param action the {@link Runnable} to run when the plugin gets disabled
+     * @param action the {@link Runnable} to run when the plugin gets enabled
      */
     public void addEnableListener(Runnable action){
         enableListeners.add(action);

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/OCMMain.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/OCMMain.java
@@ -3,7 +3,6 @@ package gvlfm78.plugin.OldCombatMechanics;
 import com.codingforcookies.armourequip.ArmourListener;
 import gvlfm78.plugin.OldCombatMechanics.hooks.PlaceholderAPIHook;
 import gvlfm78.plugin.OldCombatMechanics.hooks.api.Hook;
-import gvlfm78.plugin.OldCombatMechanics.module.Module;
 import gvlfm78.plugin.OldCombatMechanics.module.*;
 import gvlfm78.plugin.OldCombatMechanics.updater.ModuleUpdateChecker;
 import gvlfm78.plugin.OldCombatMechanics.utilities.Config;
@@ -24,6 +23,7 @@ public class OCMMain extends JavaPlugin {
     private Logger logger = getLogger();
     private OCMConfigHandler CH = new OCMConfigHandler(this);
     private List<Runnable> disableListeners = new ArrayList<>();
+    private List<Runnable> enableListeners = new ArrayList<>();
     private List<Hook> hooks = new ArrayList<>();
 
     public static OCMMain getInstance(){
@@ -79,6 +79,8 @@ public class OCMMain extends JavaPlugin {
                                 .collect(Collectors.toMap(Module::toString, module -> 1))
                 )
         );
+
+        enableListeners.forEach(Runnable::run);
 
         // Logging to console the enabling of OCM
         logger.info(pdfFile.getName() + " v" + pdfFile.getVersion() + " has been enabled");
@@ -148,5 +150,13 @@ public class OCMMain extends JavaPlugin {
      */
     public void addDisableListener(Runnable action){
         disableListeners.add(action);
+    }
+    /**
+     * Registers a runnable to run when the plugin gets disabled.
+     *
+     * @param action the {@link Runnable} to run when the plugin gets disabled
+     */
+    public void addEnableListener(Runnable action){
+        enableListeners.add(action);
     }
 }

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModulePlayerCollisions.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModulePlayerCollisions.java
@@ -7,6 +7,8 @@ import gvlfm78.plugin.OldCombatMechanics.utilities.packet.PacketManager;
 import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.Reflector;
 import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.TeamUtils;
 import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.type.ClassType;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
@@ -19,6 +21,13 @@ public class ModulePlayerCollisions extends Module {
 
     public ModulePlayerCollisions(OCMMain plugin){
         super(plugin, "disable-player-collisions");
+
+        // inject all players at startup, so the plugin still works properly after a reload
+        OCMMain.getInstance().addEnableListener(() -> {
+            for(Player player : Bukkit.getOnlinePlayers()){
+                PacketManager.getInstance().addListener(collisionPacketListener, player);
+            }
+        });
     }
 
     @EventHandler(priority = EventPriority.MONITOR)

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/Messenger.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/Messenger.java
@@ -5,6 +5,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
 import java.util.Objects;
+import java.util.logging.Level;
 
 /**
  * Created by Rayzr522 on 6/21/16.
@@ -35,6 +36,11 @@ public class Messenger {
         Objects.requireNonNull(message, "message cannot be null!");
 
         sender.sendMessage(TextUtils.colorize(String.format(message, args)));
+    }
+
+    public static void debug(String message, Throwable throwable){
+        if(!DEBUG_ENABLED) return;
+        plugin.getLogger().log(Level.INFO, message, throwable);
     }
 
     public static void debug(String message, Object... args){

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketInjector.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketInjector.java
@@ -11,6 +11,7 @@ import org.bukkit.entity.Player;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -66,7 +67,11 @@ class PacketInjector extends ChannelDuplexHandler {
             channel.pipeline().remove("ocm_handler");
         }
 
-        channel.pipeline().addBefore("packet_handler", "ocm_handler", this);
+        try{
+            channel.pipeline().addBefore("packet_handler", "ocm_handler", this);
+        } catch(NoSuchElementException e){
+            throw new NoSuchElementException("No base handler found. Was the player instantly disconnected?");
+        }
     }
 
     /**
@@ -140,6 +145,7 @@ class PacketInjector extends ChannelDuplexHandler {
             super.write(channelHandlerContext, packet, channelPromise);
             LOGGER.warning("playerWeakReference or its value is null. This should NOT happen at this stage." +
                     "Please report the error on github. (write@" + hashCode() + ")");
+            detach();
             return;
         }
 
@@ -171,6 +177,7 @@ class PacketInjector extends ChannelDuplexHandler {
             super.read(channelHandlerContext);
             LOGGER.warning("playerWeakReference or its value is null. This should NOT happen at this stage." +
                     "Please report the error on github. (read)");
+            detach();
             return;
         }
 

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketManager.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketManager.java
@@ -1,6 +1,7 @@
 package gvlfm78.plugin.OldCombatMechanics.utilities.packet;
 
 import gvlfm78.plugin.OldCombatMechanics.OCMMain;
+import gvlfm78.plugin.OldCombatMechanics.utilities.Messenger;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -68,9 +69,13 @@ public class PacketManager implements Listener {
             if(injectorMap.containsKey(player.getUniqueId())){
                 injectorMap.get(player.getUniqueId()).addPacketListener(listener);
             } else {
-                PacketInjector injector = new PacketInjector(player);
-                injector.addPacketListener(listener);
-                injectorMap.put(player.getUniqueId(), injector);
+                try{
+                    PacketInjector injector = new PacketInjector(player);
+                    injector.addPacketListener(listener);
+                    injectorMap.put(player.getUniqueId(), injector);
+                } catch(Exception e){
+                    Messenger.debug("Error attaching packet listener!", e);
+                }
             }
         }
     }

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketManager.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketManager.java
@@ -23,13 +23,6 @@ public class PacketManager implements Listener {
 
     private final Map<UUID, PacketInjector> injectorMap = new HashMap<>();
 
-    {
-        OCMMain.getInstance().addDisableListener(() -> {
-            removeAll();
-            instance = null;
-        });
-    }
-
     /**
      * Instantiates a new PacketManager
      *
@@ -37,6 +30,11 @@ public class PacketManager implements Listener {
      */
     private PacketManager(Plugin plugin){
         Bukkit.getPluginManager().registerEvents(this, plugin);
+
+        OCMMain.getInstance().addDisableListener(() -> {
+            removeAll();
+            instance = null;
+        });
     }
 
     /**


### PR DESCRIPTION
## Motivation
The packet listener was only registered when a Player joined and cleared on a reload (the latter is just the only reliable way I found to keep things sane). This lead to the packet rewriting to no longer take place after a reload.
The first commit in the PR fixes that, by always reattaching all online players. A small enable hook was picked for that, as packet injection is currently only used in that module. If it sadly becomes more widespread, it can be moved to `onEnable`.

The other commit fixes a `NoSuchElementException` that sometimes occurred on login, if the player logging in was instantly disconnected again. In that case the minecraft handlers necessary to inject the custom one were already gone. This error is now silently ignored and only logged when debug is enabled.

## Fixes
Probably #208 , #211 