### PR TITLE
Fix #229, a NBT hierarchy change

### DIFF
--- a/src/main/java/com/comphenix/example/NbtFactory.java
+++ b/src/main/java/com/comphenix/example/NbtFactory.java
@@ -6,6 +6,8 @@ import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.MapMaker;
 import com.google.common.primitives.Primitives;
+import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.Reflector;
+import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.type.ClassType;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -50,7 +52,7 @@ public class NbtFactory {
 
                 // Prepare NBT
                 COMPOUND_CLASS = getMethod(0, Modifier.STATIC, offlinePlayer, "getData").getReturnType();
-                BASE_CLASS = COMPOUND_CLASS.getSuperclass();
+                BASE_CLASS = Reflector.getClass(ClassType.NMS, "NBTBase");
                 NBT_GET_TYPE = getMethod(0, Modifier.STATIC, BASE_CLASS, "getTypeId");
                 NBT_CREATE_TAG = getMethod(Modifier.STATIC, 0, BASE_CLASS, "createTag", byte.class);
 

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/Config.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/Config.java
@@ -17,6 +17,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 
 /**
  * Created by Rayzr522 on 6/14/16.
@@ -81,7 +82,14 @@ public class Config {
 
         ModuleLoader.getModules().stream()
                 .filter(Module::isEnabled)
-                .forEach(Module::reload);
+                .forEach(module -> {
+                    try{
+                        module.reload();
+                    } catch(Exception e){
+                        plugin.getLogger()
+                                .log(Level.WARNING, "Error reloading module '" + module.toString() + "'", e);
+                    }
+                });
 
         //Setting correct attack speed and armour values for online players
         Bukkit.getOnlinePlayers().forEach(player -> {


### PR DESCRIPTION
## Problem

Starting with some newer 1.13 builds, the NBT hierarchy has changed. `NBTBase` used to be a *superclass* of `NBTTagCompound` and the comphenix class used this relationship to find the base class. Now `NBTTagCompound` *implements* the *interface* `NBTBase`, which makes the `getSuperclass` check performed return `Object`.
This causes the subsequent check for the `getTypeId` method to fail.

## Mitigation

The `NBTBase` class is now looked up via the Reflector mechanism already present in OCM. This mechanism directly resolves the runtime path of the NMS class and returns it, thus circumventing the checks.

## Closes
#229

## Other
It also adds a general exception handler catching every exception that arises during reloading a module. This prevents one bad module from screwing up the rest during reloading.