### PR TITLE
Fix the string case conversions to be locale aware

### DIFF
--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/OCMCommandHandler.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/OCMCommandHandler.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginDescriptionFile;
 
 import java.io.File;
+import java.util.Locale;
 
 public class OCMCommandHandler implements CommandExecutor {
     private static final String NO_PERMISSION = "&cYou need the permission '%s' to do that!";
@@ -47,7 +48,7 @@ public class OCMCommandHandler implements CommandExecutor {
         }
 
         // Get the sub-command
-        String sub = args[0].toLowerCase();
+        String sub = args[0].toLowerCase(Locale.ROOT);
 
         if(sub.equals("reload")){// Reloads config
             if(!sender.hasPermission("oldcombatmechanics.reload")){

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/UpdateChecker.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/UpdateChecker.java
@@ -10,6 +10,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import java.io.File;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.function.Consumer;
 
@@ -25,7 +26,7 @@ public class UpdateChecker {
                 this.updateSource = new BukkitUpdateSource(plugin, pluginFile);
                 break;
             case "auto":
-                if(Bukkit.getVersion().toLowerCase().contains("spigot")){
+                if(Bukkit.getVersion().toLowerCase(Locale.ROOT).contains("spigot")){
                     this.updateSource = new SpigotUpdateSource();
                 } else {
                     this.updateSource = new BukkitUpdateSource(plugin, pluginFile);

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleOldArmourStrength.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleOldArmourStrength.java
@@ -21,6 +21,7 @@ import org.bukkit.inventory.PlayerInventory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public class ModuleOldArmourStrength extends Module {
     private static final String ARMOR_MARK = "ArmorModifier";
@@ -111,7 +112,7 @@ public class ModuleOldArmourStrength extends Module {
     }
 
     private static String getSlotForType(Material type){
-        String typeName = type.toString().toLowerCase();
+        String typeName = type.toString().toLowerCase(Locale.ROOT);
 
         if(typeName.endsWith("helmet")){
             return "head";

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleOldToolDamage.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleOldToolDamage.java
@@ -9,6 +9,8 @@ import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.EventHandler;
 
+import java.util.Locale;
+
 public class ModuleOldToolDamage extends Module {
 
     private String[] weapons = {"sword", "axe", "pickaxe", "spade", "hoe"};
@@ -44,7 +46,7 @@ public class ModuleOldToolDamage extends Module {
     }
 
     private boolean isHolding(Material mat, String type){
-        return mat.toString().endsWith("_" + type.toUpperCase());
+        return mat.toString().endsWith("_" + type.toUpperCase(Locale.ROOT));
     }
 
     private boolean isHolding(Material mat, String[] types){

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleProjectileKnockback.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleProjectileKnockback.java
@@ -6,6 +6,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 
+import java.util.Locale;
+
 public class ModuleProjectileKnockback extends Module {
 
     public ModuleProjectileKnockback(OCMMain plugin){
@@ -22,7 +24,7 @@ public class ModuleProjectileKnockback extends Module {
             case SNOWBALL:
             case EGG:
             case ENDER_PEARL:
-                e.setDamage(module().getDouble("damage." + type.toString().toLowerCase()));
+                e.setDamage(module().getDouble("damage." + type.toString().toLowerCase(Locale.ROOT)));
             default:
                 break;
         }

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/updater/ModuleUpdateChecker.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/updater/ModuleUpdateChecker.java
@@ -10,6 +10,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerJoinEvent;
 
 import java.io.File;
+import java.util.Locale;
 
 public class ModuleUpdateChecker extends Module {
     private static Module INSTANCE;
@@ -22,7 +23,7 @@ public class ModuleUpdateChecker extends Module {
     }
 
     public static String getMode(){
-        return INSTANCE.module().getString("mode").toLowerCase();
+        return INSTANCE.module().getString("mode").toLowerCase(Locale.ROOT);
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/ConfigUtils.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/ConfigUtils.java
@@ -70,7 +70,7 @@ public class ConfigUtils {
             ConfigurationSection drinkable = potionSection.getConfigurationSection("drinkable");
             ConfigurationSection splash = potionSection.getConfigurationSection("splash");
 
-            PotionType potionType = PotionType.valueOf(potionName.toUpperCase());
+            PotionType potionType = PotionType.valueOf(potionName.toUpperCase(Locale.ROOT));
             durationsHashMap.put(potionType, new PotionDurations(getGenericDurations(drinkable), getGenericDurations(splash)));
         }
 


### PR DESCRIPTION
## Problem

On some locales (like turkish) certain characters do not map to the upper case you expect. For turkish that is `i/I` becoming `İ`. This broke the lookup in all kinds of things, as suddenly you have very weird strings.

## Mitigation
Instead of using the default locale it now explicitely uses the `ROOT` locale which is guaranteed to be what you actually want here.