### PR TITLE
Fix #233 ocm reload bug in 1.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.12.2-R0.1-SNAPSHOT</version>
+            <version>1.13.1-R0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>net.gravitydevelopment.updater</groupId>

--- a/src/main/java/com/codingforcookies/armourequip/ArmourType.java
+++ b/src/main/java/com/codingforcookies/armourequip/ArmourType.java
@@ -3,10 +3,7 @@ package com.codingforcookies.armourequip;
 import org.bukkit.inventory.ItemStack;
 
 /**
- * @Author Borlea
- * @Github https://github.com/borlea/
- * @Website http://codingforcookies.com/
- * @Since Jul 30, 2015 6:46:16 PM
+ * Enum declarations by (<a href="http://codingforcookies.com/">Barlea</a>), methods by us.
  */
 public enum ArmourType {
     HELMET(5), CHESTPLATE(6), LEGGINGS(7), BOOTS(8);
@@ -27,33 +24,19 @@ public enum ArmourType {
         if(itemStack == null){
             return null;
         }
-        switch(itemStack.getType()){
-            case DIAMOND_HELMET:
-            case GOLD_HELMET:
-            case IRON_HELMET:
-            case CHAINMAIL_HELMET:
-            case LEATHER_HELMET:
-                return HELMET;
-            case DIAMOND_CHESTPLATE:
-            case GOLD_CHESTPLATE:
-            case IRON_CHESTPLATE:
-            case CHAINMAIL_CHESTPLATE:
-            case LEATHER_CHESTPLATE:
-                return CHESTPLATE;
-            case DIAMOND_LEGGINGS:
-            case GOLD_LEGGINGS:
-            case IRON_LEGGINGS:
-            case CHAINMAIL_LEGGINGS:
-            case LEATHER_LEGGINGS:
-                return LEGGINGS;
-            case DIAMOND_BOOTS:
-            case GOLD_BOOTS:
-            case IRON_BOOTS:
-            case CHAINMAIL_BOOTS:
-            case LEATHER_BOOTS:
-                return BOOTS;
-            default:
-                return null;
+
+        String typeName = itemStack.getType().name();
+
+        if(typeName.endsWith("_HELMET")){
+            return HELMET;
+        } else if(typeName.endsWith("_CHESTPLATE")){
+            return CHESTPLATE;
+        } else if(typeName.endsWith("_LEGGINGS")){
+            return LEGGINGS;
+        } else if(typeName.endsWith("_BOOTS")){
+            return BOOTS;
+        } else {
+            return null;
         }
     }
 

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleNoLapisEnchantments.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleNoLapisEnchantments.java
@@ -15,9 +15,16 @@ import org.bukkit.permissions.Permissible;
 
 public class ModuleNoLapisEnchantments extends Module {
 
+    private Material lapisLazuliMaterial;
 
     public ModuleNoLapisEnchantments(OCMMain plugin){
         super(plugin, "no-lapis-enchantments");
+
+        try{
+            lapisLazuliMaterial = Material.valueOf("INK_SACK");
+        } catch(IllegalArgumentException ignored){
+            lapisLazuliMaterial = Material.LAPIS_LAZULI;
+        }
     }
 
     @EventHandler
@@ -40,10 +47,16 @@ public class ModuleNoLapisEnchantments extends Module {
         if(!hasPermission(e.getWhoClicked())) return;
 
         ItemStack item = e.getCurrentItem();
-        if(item != null && (
-                (item.getType() == Material.INK_SACK && e.getRawSlot() == 1) ||
-                        (e.getCursor() != null && e.getCursor().getType() == Material.INK_SACK && e.getClick() == ClickType.DOUBLE_CLICK)))
+
+        if(item == null){
+            return;
+        }
+
+        if(item.getType() == lapisLazuliMaterial && e.getRawSlot() == 1){
             e.setCancelled(true);
+        } else if(e.getCursor() != null && e.getCursor().getType() == lapisLazuliMaterial && e.getClick() == ClickType.DOUBLE_CLICK){
+            e.setCancelled(true);
+        }
     }
 
     @EventHandler

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,6 +6,7 @@ description: Reverts to pre-1.9 combat mechanics
 website: http://dev.bukkit.org/bukkit-plugins/oldcombatmechanics
 load: POSTWORLD
 softdepend: [PlaceholderAPI, Spartan]
+api-version: 1.13
 
 commands:
   OldCombatMechanics:


### PR DESCRIPTION
## Changes
* Set the target API version and dependency to 1.13

* Fix the resulting conflicts (material names)

## Fixes
#233 

## Problems
Haven't found any, but have a look at it. The name based armour matching could go bad if they change their naming scheme for some reason.