### PR TITLE
Prevent sweep particle packets from being sent

### DIFF
--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModulePlayerCollisions.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModulePlayerCollisions.java
@@ -30,7 +30,7 @@ public class ModulePlayerCollisions extends Module {
         });
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerLogin(PlayerJoinEvent e){
         if(isEnabled(e.getPlayer().getWorld())){
             TeamUtils.sendTeamPacket(e.getPlayer());

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleSwordSweep.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleSwordSweep.java
@@ -1,7 +1,13 @@
 package gvlfm78.plugin.OldCombatMechanics.module;
 
 import gvlfm78.plugin.OldCombatMechanics.OCMMain;
+import gvlfm78.plugin.OldCombatMechanics.utilities.Messenger;
 import gvlfm78.plugin.OldCombatMechanics.utilities.damage.ToolDamage;
+import gvlfm78.plugin.OldCombatMechanics.utilities.packet.PacketAdapter;
+import gvlfm78.plugin.OldCombatMechanics.utilities.packet.PacketEvent;
+import gvlfm78.plugin.OldCombatMechanics.utilities.packet.PacketManager;
+import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.sweep.SweepPacketDetector;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -12,6 +18,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -26,9 +33,12 @@ public class ModuleSwordSweep extends Module {
     private BukkitRunnable task;
     private List<Location> sweepLocations = new ArrayList<>();
     private EntityDamageEvent.DamageCause sweepDamageCause;
+    private ParticleListener particleListener;
 
     public ModuleSwordSweep(OCMMain plugin){
         super(plugin, "disable-sword-sweep");
+
+        this.particleListener = new ParticleListener();
 
         try{
             // Will be available from some 1.11 version onwards
@@ -36,6 +46,14 @@ public class ModuleSwordSweep extends Module {
         } catch(IllegalArgumentException e){
             sweepDamageCause = null;
         }
+
+
+        // inject all players at startup, so the plugin still works properly after a reload
+        OCMMain.getInstance().addEnableListener(() -> {
+            for(Player player : Bukkit.getOnlinePlayers()){
+                PacketManager.getInstance().addListener(particleListener, player);
+            }
+        });
     }
 
     @Override
@@ -57,6 +75,12 @@ public class ModuleSwordSweep extends Module {
         };
 
         task.runTaskTimer(plugin, 0, 1);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerLogin(PlayerJoinEvent e){
+        // always attach the listener, it checks internally
+        PacketManager.getInstance().addListener(particleListener, e.getPlayer());
     }
 
     //Changed from HIGHEST to LOWEST to support DamageIndicator plugin
@@ -112,4 +136,29 @@ public class ModuleSwordSweep extends Module {
         return mat.toString().endsWith("_SWORD");
     }
 
+    private class ParticleListener extends PacketAdapter {
+
+        private boolean disabledDueToError;
+
+        @Override
+        public void onPacketSend(PacketEvent packetEvent){
+            if(disabledDueToError || !isEnabled(packetEvent.getPlayer().getWorld())){
+                return;
+            }
+
+            try{
+                if(SweepPacketDetector.getInstance().isSweepPacket(packetEvent.getPacket())){
+                    packetEvent.setCancelled(true);
+                }
+            } catch(Exception e){
+                disabledDueToError = true;
+                Messenger.warn(
+                        e,
+                        "Error detecting sweep packets. Please report it along with the following exception " +
+                                "on github." +
+                                "Sweep cancellation should still work, but particles might show up."
+                );
+            }
+        }
+    }
 }

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/Messenger.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/Messenger.java
@@ -24,6 +24,10 @@ public class Messenger {
         plugin.getLogger().info(TextUtils.stripColor(String.format(message, args)));
     }
 
+    public static void warn(Throwable e, String message, Object... args){
+        plugin.getLogger().log(Level.WARNING, TextUtils.stripColor(String.format(message, args)), e);
+    }
+
     /**
      * This will format any ampersand (&) color codes, format any args passed to it using {@link String#format(String, Object...)}, and then send the message to the specified {@link CommandSender}.
      *

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/reflection/Reflector.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/reflection/Reflector.java
@@ -40,6 +40,44 @@ public class Reflector {
         return version;
     }
 
+    /**
+     * Checks if the current server version is newer or equal to the one provided.
+     *
+     * @param major the target major version
+     * @param minor the target minor version. 0 for all
+     * @param patch the target patch version. 0 for all
+     * @return true of the server version is newer or equal to the one provided
+     */
+    public static boolean versionIsNewerOrEqualAs(int major, int minor, int patch){
+        if(getMajorVersion() < major){
+            return false;
+        }
+        if(getMinorVersion() < minor){
+            return false;
+        }
+        return getPatchVersion() >= patch;
+    }
+
+    private static int getMajorVersion(){
+        return Integer.parseInt(getVersionSanitized().split("_")[0]);
+    }
+
+    private static String getVersionSanitized(){
+        return getVersion().replaceAll("[^\\d_]", "");
+    }
+
+    private static int getMinorVersion(){
+        return Integer.parseInt(getVersionSanitized().split("_")[1]);
+    }
+
+    private static int getPatchVersion(){
+        String[] split = getVersionSanitized().split("_");
+        if(split.length < 3){
+            return 0;
+        }
+        return Integer.parseInt(split[2]);
+    }
+
     public static Class<?> getClass(ClassType type, String name){
         try{
             return Class.forName(String.format("%s.%s.%s", type.getPackage(), version, name));
@@ -55,10 +93,6 @@ public class Reflector {
                 .filter(method -> method.getName().equals(name))
                 .findFirst()
                 .orElse(null);
-    }
-
-    public static void invokeMethod(Object object, String name, Object... params) throws InvocationTargetException, IllegalAccessException{
-        getMethod((object.getClass()), name).invoke(object, params);
     }
 
     public static <T> T invokeMethod(Method method, Object handle, Object... params){

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/reflection/sweep/AbstractSweepPacketDetector.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/reflection/sweep/AbstractSweepPacketDetector.java
@@ -1,0 +1,53 @@
+package gvlfm78.plugin.OldCombatMechanics.utilities.reflection.sweep;
+
+import gvlfm78.plugin.OldCombatMechanics.OCMMain;
+import gvlfm78.plugin.OldCombatMechanics.utilities.packet.Packet;
+import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.Reflector;
+import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.type.PacketType;
+import org.bukkit.Bukkit;
+
+import java.lang.reflect.Field;
+import java.util.logging.Level;
+
+abstract class AbstractSweepPacketDetector implements SweepPacketDetector {
+
+    static final Class<?> PACKET_CLASS = Reflector.Packets.getPacket(PacketType.PlayOut, "WorldParticles");
+
+    /**
+     * Checks if the type of the packet is correct.
+     *
+     * @param packet the packet
+     * @return true if it is of the correct type
+     */
+    boolean isWrongPacketType(Packet packet){
+        return packet.getPacketClass() != PACKET_CLASS;
+    }
+
+    /**
+     * Returns the value of a given field, but does not set {@link Field#setAccessible(boolean)}.
+     *
+     * @param field  the field to get the value for
+     * @param handle the handle
+     * @return null if an error occurred, the result otherwise
+     */
+    Object tryGetField(Field field, Object handle){
+        try{
+            return field.get(handle);
+        } catch(IllegalAccessException e){
+            OCMMain.getInstance().getLogger().log(Level.INFO, "Error getting field " + field, e);
+        }
+        return null;
+    }
+
+    /**
+     * Throws an exception indicating that the element wasn't found.
+     *
+     * @param name the name of the element
+     */
+    void throwNewElementNotFoundException(String name){
+        throw new IllegalStateException(
+                "Couldn't find " + name + ". Please report this on github. I am running server version "
+                        + Bukkit.getServer().getVersion()
+        );
+    }
+}

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/reflection/sweep/SweepPacketDetector.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/reflection/sweep/SweepPacketDetector.java
@@ -1,0 +1,28 @@
+package gvlfm78.plugin.OldCombatMechanics.utilities.reflection.sweep;
+
+import gvlfm78.plugin.OldCombatMechanics.utilities.packet.Packet;
+import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.Reflector;
+
+public interface SweepPacketDetector {
+
+    /**
+     * Checks if a packet is a sweep packet.
+     *
+     * @param packet the packet to check
+     * @return true if this is a sweep packet
+     */
+    boolean isSweepPacket(Packet packet);
+
+    /**
+     * Returns the instance of a detector that should be compatible with the current server version.
+     *
+     * @return the {@link SweepPacketDetector} instance to use
+     */
+    static SweepPacketDetector getInstance(){
+        if(Reflector.versionIsNewerOrEqualAs(1, 13, 0)){
+            return new SweepPacketDetectorFrom1_13();
+        } else {
+            return new SweepPacketDetectorUpTo1_12();
+        }
+    }
+}

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/reflection/sweep/SweepPacketDetectorFrom1_13.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/reflection/sweep/SweepPacketDetectorFrom1_13.java
@@ -1,0 +1,55 @@
+package gvlfm78.plugin.OldCombatMechanics.utilities.reflection.sweep;
+
+import gvlfm78.plugin.OldCombatMechanics.utilities.packet.Packet;
+import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.Reflector;
+import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.type.ClassType;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+class SweepPacketDetectorFrom1_13 extends AbstractSweepPacketDetector {
+
+    private Field particleParamField;
+    private Method particleParamNameMethod;
+
+    SweepPacketDetectorFrom1_13(){
+        for(Field field : PACKET_CLASS.getDeclaredFields()){
+            if(field.getType().getSimpleName().equals("ParticleParam")){
+                particleParamField = field;
+                particleParamField.setAccessible(true);
+            }
+        }
+        if(particleParamField == null){
+            throwNewElementNotFoundException("Particle param field");
+        }
+
+        Class<?> particleParamClass = Reflector.getClass(ClassType.NMS, "ParticleParam");
+        if(particleParamClass == null){
+            throwNewElementNotFoundException("ParticleParam class");
+        }
+
+        for(Method method : particleParamClass.getMethods()){
+            if(method.getReturnType() == String.class){
+                particleParamNameMethod = method;
+            }
+        }
+        if(particleParamNameMethod == null){
+            throwNewElementNotFoundException("Particle param description method");
+        }
+    }
+
+    @Override
+    public boolean isSweepPacket(Packet packet){
+        if(isWrongPacketType(packet)){
+            return false;
+        }
+
+        Object nmsPacket = packet.getNMSPacket();
+
+        Object particleParam = tryGetField(particleParamField, nmsPacket);
+
+        String minecraftName = Reflector.invokeMethod(particleParamNameMethod, particleParam);
+
+        return minecraftName.contains("sweep");
+    }
+}

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/reflection/sweep/SweepPacketDetectorUpTo1_12.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/reflection/sweep/SweepPacketDetectorUpTo1_12.java
@@ -1,0 +1,36 @@
+package gvlfm78.plugin.OldCombatMechanics.utilities.reflection.sweep;
+
+import gvlfm78.plugin.OldCombatMechanics.utilities.packet.Packet;
+
+import java.lang.reflect.Field;
+import java.util.Locale;
+
+class SweepPacketDetectorUpTo1_12 extends AbstractSweepPacketDetector {
+
+    private Field enumParticleField;
+
+    SweepPacketDetectorUpTo1_12(){
+        for(Field field : PACKET_CLASS.getDeclaredFields()){
+            if(field.getType().getSimpleName().equals("EnumParticle")){
+                this.enumParticleField = field;
+                this.enumParticleField.setAccessible(true);
+            }
+        }
+        if(enumParticleField == null){
+            throwNewElementNotFoundException("EnumParticle field");
+        }
+    }
+
+    @Override
+    public boolean isSweepPacket(Packet packet){
+        if(isWrongPacketType(packet)){
+            return false;
+        }
+
+        Object nmsPacket = packet.getNMSPacket();
+
+        Enum<?> enumParticle = (Enum<?>) tryGetField(enumParticleField, nmsPacket);
+
+        return enumParticle.name().toUpperCase(Locale.ROOT).contains("SWEEP");
+    }
+}


### PR DESCRIPTION
## Function
Sweeps already did no damage, but now the visual indication of one should be gone as well.

It works by simply cancelling the packet if it is:
a) A particle packet
b) Conveys information for the "Sweep" packet

This is done via two different adapters in order to work on 1.13 and up and also on 1.9 to 1.12.2.

## Relates to
[#228](https://github.com/gvlfm78/BukkitOldCombatMechanics/issues/228#issuecomment-419660828)

## Problems
This might break with a newer minecraft version as it uses more than the official API. In that case however, unless the whole packet listener system is broken (which is a lot less likely), the module should log an error, disable the particle suppression and carry on.