### PR TITLE
Stop using getPotionEffect as it is not available in 1.9

### DIFF
--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleOldPotionEffects.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleOldPotionEffects.java
@@ -34,7 +34,7 @@ public class ModuleOldPotionEffects extends Module {
                     PotionType.AWKWARD, PotionType.MUNDANE, PotionType.THICK,
                     PotionType.UNCRAFTABLE, PotionType.WATER};
 
-    public ModuleOldPotionEffects(OCMMain plugin) {
+    public ModuleOldPotionEffects(OCMMain plugin){
         super(plugin, "old-potion-effects");
         reload();
     }
@@ -69,7 +69,7 @@ public class ModuleOldPotionEffects extends Module {
         PotionEffect pe = new PotionEffect(pet, duration, amplifier);
 
         Player player = event.getPlayer();
-        setNewPotionEffect(player,pet,pe);
+        setNewPotionEffect(player, pet, pe);
 
         //Remove item from hand since we cancelled the event
         if(player.getGameMode() != GameMode.SURVIVAL) return;
@@ -116,7 +116,7 @@ public class ModuleOldPotionEffects extends Module {
 
         PotionEffect pe = new PotionEffect(pet, duration, potionEffect.getAmplifier());
 
-        event.getAffectedEntities().forEach(livingEntity -> setNewPotionEffect(livingEntity,pet,pe));
+        event.getAffectedEntities().forEach(livingEntity -> setNewPotionEffect(livingEntity, pet, pe));
     }
 
     private boolean isExcludedPotion(PotionType pt){
@@ -125,7 +125,10 @@ public class ModuleOldPotionEffects extends Module {
 
     private void setNewPotionEffect(LivingEntity livingEntity, PotionEffectType pet, PotionEffect pe){
         if(livingEntity.hasPotionEffect(pet)){
-            PotionEffect activepe = livingEntity.getPotionEffect(pet);
+            PotionEffect activepe = livingEntity.getActivePotionEffects().stream()
+                    .filter(potionEffect -> potionEffect.getType().equals(pet))
+                    .findAny()
+                    .orElseThrow(() -> new RuntimeException("Couldn't find potion effect"));
 
             int remainingDuration = activepe.getDuration();
 
@@ -156,7 +159,7 @@ public class ModuleOldPotionEffects extends Module {
         return duration * 20;
     }
 
-    @EventHandler (ignoreCancelled = true)
+    @EventHandler(ignoreCancelled = true)
     public void onDamageByEntity(OCMEntityDamageByEntityEvent event){
         Entity damager = event.getDamager();
 

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleOldPotionEffects.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleOldPotionEffects.java
@@ -5,6 +5,7 @@ import gvlfm78.plugin.OldCombatMechanics.utilities.ConfigUtils;
 import gvlfm78.plugin.OldCombatMechanics.utilities.damage.OCMEntityDamageByEntityEvent;
 import gvlfm78.plugin.OldCombatMechanics.utilities.potions.GenericPotionDurations;
 import gvlfm78.plugin.OldCombatMechanics.utilities.potions.PotionDurations;
+import gvlfm78.plugin.OldCombatMechanics.utilities.potions.PotionEffects;
 import org.apache.commons.lang.ArrayUtils;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -125,10 +126,7 @@ public class ModuleOldPotionEffects extends Module {
 
     private void setNewPotionEffect(LivingEntity livingEntity, PotionEffectType pet, PotionEffect pe){
         if(livingEntity.hasPotionEffect(pet)){
-            PotionEffect activepe = livingEntity.getActivePotionEffects().stream()
-                    .filter(potionEffect -> potionEffect.getType().equals(pet))
-                    .findAny()
-                    .orElseThrow(() -> new RuntimeException("Couldn't find potion effect"));
+            PotionEffect activepe = PotionEffects.getOrNull(livingEntity, pet);
 
             int remainingDuration = activepe.getDuration();
 

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/damage/OCMEntityDamageByEntityEvent.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/damage/OCMEntityDamageByEntityEvent.java
@@ -1,5 +1,6 @@
 package gvlfm78.plugin.OldCombatMechanics.utilities.damage;
 
+import gvlfm78.plugin.OldCombatMechanics.utilities.potions.PotionEffects;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -91,9 +92,7 @@ public class OCMEntityDamageByEntityEvent extends Event implements Cancellable {
         }
 
         //amplifier 0 = Strength I    amplifier 1 = Strength II
-        int amplifier = le.getActivePotionEffects().stream()
-                .filter(potionEffect -> potionEffect.getType().equals(PotionEffectType.INCREASE_DAMAGE))
-                .findAny()
+        int amplifier = PotionEffects.get(le, PotionEffectType.INCREASE_DAMAGE)
                 .map(PotionEffect::getAmplifier)
                 .orElse(-1);
 

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/damage/OCMEntityDamageByEntityEvent.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/damage/OCMEntityDamageByEntityEvent.java
@@ -11,6 +11,7 @@ import org.bukkit.event.HandlerList;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
 import static gvlfm78.plugin.OldCombatMechanics.utilities.Messenger.debug;
@@ -25,7 +26,9 @@ public class OCMEntityDamageByEntityEvent extends Event implements Cancellable {
         return handlers;
     }
 
-    public static HandlerList getHandlerList(){ return handlers;}
+    public static HandlerList getHandlerList(){
+        return handlers;
+    }
 
     private Entity damager, damagee;
     private DamageCause cause;
@@ -63,19 +66,19 @@ public class OCMEntityDamageByEntityEvent extends Event implements Cancellable {
 
         EntityType entity = damagee.getType();
 
-        debug(le,"Raw damage: " + rawDamage);
+        debug(le, "Raw damage: " + rawDamage);
 
         mobEnchantmentsDamage = MobDamage.applyEntityBasedDamage(entity, weapon, rawDamage) - rawDamage;
 
         sharpnessLevel = weapon.getEnchantmentLevel(Enchantment.DAMAGE_ALL);
         sharpnessDamage = DamageUtils.getNewSharpnessDamage(sharpnessLevel);
 
-        debug(le,"Mob: " + mobEnchantmentsDamage + " Sharpness: " + sharpnessDamage);
+        debug(le, "Mob: " + mobEnchantmentsDamage + " Sharpness: " + sharpnessDamage);
 
         //Amount of damage including potion effects and critical hits
-        double tempDamage =  rawDamage - mobEnchantmentsDamage - sharpnessDamage;
+        double tempDamage = rawDamage - mobEnchantmentsDamage - sharpnessDamage;
 
-        debug(le,"No ench damage: " + tempDamage);
+        debug(le, "No ench damage: " + tempDamage);
 
         //Check if it's a critical hit
         if(le instanceof Player){
@@ -83,26 +86,29 @@ public class OCMEntityDamageByEntityEvent extends Event implements Cancellable {
             if(DamageUtils.isCriticalHit(player)){
                 criticalMultiplier = 1.5;
                 tempDamage /= 1.5;
-                debug(player,"Critical hit detected");
+                debug(player, "Critical hit detected");
             }
         }
 
         //amplifier 0 = Strength I    amplifier 1 = Strength II
-        int amplifier = le.hasPotionEffect(PotionEffectType.INCREASE_DAMAGE) ?
-                le.getPotionEffect(PotionEffectType.INCREASE_DAMAGE).getAmplifier() : -1;
+        int amplifier = le.getActivePotionEffects().stream()
+                .filter(potionEffect -> potionEffect.getType().equals(PotionEffectType.INCREASE_DAMAGE))
+                .findAny()
+                .map(PotionEffect::getAmplifier)
+                .orElse(-1);
 
         strengthLevel = ++amplifier;
 
-        strengthModifier = strengthLevel *3;
+        strengthModifier = strengthLevel * 3;
 
-        debug(le,"Strength Modifier: " + strengthModifier);
+        debug(le, "Strength Modifier: " + strengthModifier);
 
         if(le.hasPotionEffect(PotionEffectType.WEAKNESS)) weaknessModifier = -4;
 
-        debug(le,"Weakness Modifier: " + weaknessModifier);
+        debug(le, "Weakness Modifier: " + weaknessModifier);
 
         baseDamage = tempDamage + weaknessModifier - strengthModifier;
-        debug(le,"Base tool damage: " + baseDamage);
+        debug(le, "Base tool damage: " + baseDamage);
     }
 
     public Entity getDamager(){

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/potions/PotionEffects.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/potions/PotionEffects.java
@@ -1,0 +1,52 @@
+package gvlfm78.plugin.OldCombatMechanics.utilities.potions;
+
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import java.util.Optional;
+
+public class PotionEffects {
+
+    private static boolean canUseGetPotionEffectsMethod;
+
+    static{
+        try{
+            LivingEntity.class.getDeclaredMethod("getPotionEffect", PotionEffectType.class);
+
+            canUseGetPotionEffectsMethod = true;
+        } catch(NoSuchMethodException e){
+            canUseGetPotionEffectsMethod = false;
+        }
+    }
+
+    /**
+     * Returns the {@link PotionEffect} of a given {@link PotionEffectType} for a given {@link LivingEntity}, if present.
+     *
+     * @param entity the entity to query
+     * @param type   the type to search
+     * @return the {@link PotionEffect} if present
+     */
+    public static Optional<PotionEffect> get(LivingEntity entity, PotionEffectType type){
+        return Optional.ofNullable(getOrNull(entity, type));
+    }
+
+    /**
+     * Returns the {@link PotionEffect} of a given {@link PotionEffectType} for a given {@link LivingEntity}, if present.
+     *
+     * @param entity the entity to query
+     * @param type   the type to search
+     * @return the {@link PotionEffect} or null if not present
+     */
+    public static PotionEffect getOrNull(LivingEntity entity, PotionEffectType type){
+        if(canUseGetPotionEffectsMethod){
+            return entity.getPotionEffect(type);
+        }
+
+
+        return entity.getActivePotionEffects().stream()
+                .filter(potionEffect -> potionEffect.getType().equals(type))
+                .findAny()
+                .orElse(null);
+    }
+}


### PR DESCRIPTION
## Problem
The method `getPotionEffect` was only introduced *after* 1.9, so we can sadly not use that in this plugin.

It was subsequently replaced with a less efficient stream, which returns the same by filtering `getActivePotionEffects`.

## Relates to
Another error brought up in #232 

## Problems
This shows that building against spigot 1.13/1.12 introduces some risks. However, we can't properly support newer versions without targeting that, as we rely on things like a `NamespacedKey` being present at compile time. Not sure what we want to do in that regard?