### PR TITLE
Supress packet injector warning

### DIFF
--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketInjector.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketInjector.java
@@ -1,9 +1,10 @@
 package gvlfm78.plugin.OldCombatMechanics.utilities.packet;
 
-import gvlfm78.plugin.OldCombatMechanics.OCMMain;
+import gvlfm78.plugin.OldCombatMechanics.utilities.Messenger;
 import gvlfm78.plugin.OldCombatMechanics.utilities.reflection.Reflector;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import org.bukkit.entity.Player;
@@ -13,17 +14,13 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * A simple packet injector, to modify the packets sent and received
  */
 class PacketInjector extends ChannelDuplexHandler {
 
-    private static final Logger LOGGER = OCMMain.getInstance().getLogger();
-
-    private boolean isClosed;
+    private volatile boolean isClosed;
     private Channel channel;
     // There are a lot more reads than writes, so performance should be okay
     private List<PacketListener> packetListeners = new CopyOnWriteArrayList<>();
@@ -53,10 +50,7 @@ class PacketInjector extends ChannelDuplexHandler {
      */
     private void attach(Player player) throws Exception{
 
-        // Lengthy way of doing: ( (CraftPlayer) handle
-        // ).getHandle().playerConnection.networkManager.channel
         Object playerConnection = PacketSender.getInstance().getConnection(player);
-
 
         Object manager = Reflector.getFieldValue(playerConnection, "networkManager");
 
@@ -64,6 +58,14 @@ class PacketInjector extends ChannelDuplexHandler {
 
         // remove old listener, if it wasn't properly cleared up
         if(channel.pipeline().get("ocm_handler") != null){
+            debug("Old listener lingered around");
+
+            ChannelHandler old = channel.pipeline().get("ocm_handler");
+            if(old instanceof PacketInjector){
+                debug("Detaching old listener");
+                ((PacketInjector) old).detach();
+            }
+
             // remove old
             channel.pipeline().remove("ocm_handler");
         }
@@ -79,30 +81,25 @@ class PacketInjector extends ChannelDuplexHandler {
      * Removes this handler
      */
     void detach(){
+        debug("Detaching injector... (%d)", hashCode());
         if(isClosed || !channel.isOpen()){
+            debug("Closed(%b) or channel closed(%b) already! (%d)", isClosed, !channel.isOpen(), hashCode());
             return;
         }
-        isClosed = true;
         channel.eventLoop().submit(() -> {
             channel.pipeline().remove(this);
 
             // only clear the channel after the last access
             channel = null;
+            isClosed = true;
+
+            // clear references. Probably not needed, but I am not sure about the
+            // channel.
+            playerWeakReference.clear();
+            packetListeners.clear();
+
+            debug("Injector successfully detached (%d)", hashCode());
         });
-
-        // clear references. Probably not needed, but I am not sure about the
-        // channel.
-        playerWeakReference.clear();
-        packetListeners.clear();
-    }
-
-    /**
-     * Checks if this handler is closed
-     *
-     * @return True if the handler is closed
-     */
-    private boolean isClosed(){
-        return isClosed;
     }
 
     /**
@@ -113,7 +110,7 @@ class PacketInjector extends ChannelDuplexHandler {
      */
     void addPacketListener(PacketListener packetListener){
         Objects.requireNonNull(packetListener, "packetListener can not be null");
-        if(isClosed()){
+        if(isClosed){
             throw new IllegalStateException("Channel already closed. Adding of listener invalid");
         }
         packetListeners.add(packetListener);
@@ -142,11 +139,14 @@ class PacketInjector extends ChannelDuplexHandler {
             throws Exception{
 
         if(playerWeakReference == null || playerWeakReference.get() == null){
+            debug(
+                    "playerWeakReference or its value is null. This should NOT happen at this stage. " +
+                            "(write@%d)", hashCode()
+            );
+            detach();
+
             // bubble up
             super.write(channelHandlerContext, packet, channelPromise);
-            LOGGER.warning("playerWeakReference or its value is null. This should NOT happen at this stage." +
-                    "Please report the error on github. (write@" + hashCode() + ")");
-            detach();
             return;
         }
 
@@ -162,8 +162,7 @@ class PacketInjector extends ChannelDuplexHandler {
                     packetListener.onPacketSend(event);
                 }
             } catch(Exception e){
-                LOGGER.log(Level.WARNING,
-                        "Error in a Packet Listener (send). Nag the author of that plugin!", e);
+                Messenger.warn(e, "Error in a packet listener (send).");
             }
         }
 
@@ -176,11 +175,14 @@ class PacketInjector extends ChannelDuplexHandler {
     @Override
     public void channelRead(ChannelHandlerContext channelHandlerContext, Object packet) throws Exception{
         if(playerWeakReference == null || playerWeakReference.get() == null){
-            // bubble up
-            super.read(channelHandlerContext);
-            LOGGER.warning("playerWeakReference or its value is null. This should NOT happen at this stage." +
-                    "Please report the error on github. (read)");
+            debug(
+                    "playerWeakReference or its value is null. This should NOT happen at this stage. " +
+                            "(read@%d)", hashCode()
+            );
             detach();
+
+            // bubble up
+            super.channelRead(channelHandlerContext, packet);
             return;
         }
 
@@ -196,8 +198,7 @@ class PacketInjector extends ChannelDuplexHandler {
                     packetListener.onPacketReceived(event);
                 }
             } catch(Exception e){
-                LOGGER.log(Level.WARNING,
-                        "Error in a Packet Listener (receive). Nag the author of that plugin!", e);
+                Messenger.warn(e, "Error in a packet listener (receive).");
             }
         }
 
@@ -205,5 +206,9 @@ class PacketInjector extends ChannelDuplexHandler {
         if(!event.isCancelled()){
             super.channelRead(channelHandlerContext, packet);
         }
+    }
+
+    private static void debug(String message, Object... formatArgs){
+        Messenger.debug("PacketInjector: " + message, formatArgs);
     }
 }

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketInjector.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/packet/PacketInjector.java
@@ -9,10 +9,10 @@ import io.netty.channel.ChannelPromise;
 import org.bukkit.entity.Player;
 
 import java.lang.ref.WeakReference;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -25,7 +25,8 @@ class PacketInjector extends ChannelDuplexHandler {
 
     private boolean isClosed;
     private Channel channel;
-    private List<PacketListener> packetListeners = new ArrayList<>();
+    // There are a lot more reads than writes, so performance should be okay
+    private List<PacketListener> packetListeners = new CopyOnWriteArrayList<>();
     private WeakReference<Player> playerWeakReference;
 
     /**
@@ -157,7 +158,9 @@ class PacketInjector extends ChannelDuplexHandler {
 
         for(PacketListener packetListener : packetListeners){
             try{
-                packetListener.onPacketSend(event);
+                if(!isClosed){
+                    packetListener.onPacketSend(event);
+                }
             } catch(Exception e){
                 LOGGER.log(Level.WARNING,
                         "Error in a Packet Listener (send). Nag the author of that plugin!", e);
@@ -189,7 +192,9 @@ class PacketInjector extends ChannelDuplexHandler {
 
         for(PacketListener packetListener : packetListeners){
             try{
-                packetListener.onPacketReceived(event);
+                if(!isClosed){
+                    packetListener.onPacketReceived(event);
+                }
             } catch(Exception e){
                 LOGGER.log(Level.WARNING,
                         "Error in a Packet Listener (receive). Nag the author of that plugin!", e);


### PR DESCRIPTION
Sorry for the larger PR, it could have been 2 smaller ones, but I think they fit closely enough together.


## Problem (1)
The PacketInjector liked to randomly delight users with an error message it spammed on every packet sent/read, when its player reference was cleared out.

(Recently brought up again in #248)

## Measures taken (1)
This PR only clears that reference when the listener was actually removed (in the submitted event loop task) and additionally hides this message unless you have the debug mode enabled.

## Problem (2)
Fix the collision sometimes not being updated when the team was disbanded in a world where the module was disabled and then the player changed worlds.

## Measures taken (2)
To combat this, the saved packet is always updated now, but a new packet is only sent on demand, if it was disbanded.

## Problem (3)
Fix a ConcurrentModificationException in the PacketInjector

Caused by the listeners being cleared out in the middle of a packet dispatch.

## Measures taken (3)
Converted to a concurrent collection (hacky) and also check to not call PacketListeners when the listener is already detached.