### PR TITLE
Fix NPE when the server returned null and not AIR

### DIFF
--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/damage/OCMEntityDamageByEntityEvent.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/damage/OCMEntityDamageByEntityEvent.java
@@ -1,6 +1,7 @@
 package gvlfm78.plugin.OldCombatMechanics.utilities.damage;
 
 import gvlfm78.plugin.OldCombatMechanics.utilities.potions.PotionEffects;
+import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -63,6 +64,10 @@ public class OCMEntityDamageByEntityEvent extends Event implements Cancellable {
 
         EntityEquipment equipment = le.getEquipment();
         weapon = equipment.getItemInMainHand();
+        // Yay paper. Why do you need to return null here?
+        if(weapon == null){
+            weapon = new ItemStack(Material.AIR);
+        }
 
         EntityType entity = damagee.getType();
 


### PR DESCRIPTION
## Problem
NPE when hitting an entity / getting hit without an item in the main hand.

## Fix
Just null check it and work with AIR, as that is what would be returned otherwise.

## Closes
#258 