### PR TITLE
Fix a NPE if a team packet contained no players

### DIFF
--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/teams/TeamUtils.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/utilities/teams/TeamUtils.java
@@ -71,7 +71,8 @@ public class TeamUtils {
      * @return true if the packet targets the player
      */
     public static boolean targetsPlayer(Object packet, Player player){
-        return getTeamMembers(packet).contains(player.getName());
+        Collection<String> teamMembers = getTeamMembers(packet);
+        return teamMembers != null && teamMembers.contains(player.getName());
     }
 
     /**


### PR DESCRIPTION
This can happen if the player field is not needed (e.g. at disband)

References:
#257, #263 