### PR TITLE
Fix #278 fishing rod affecting NPCs

### DIFF
--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleFishingKnockback.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleFishingKnockback.java
@@ -66,6 +66,10 @@ public class ModuleFishingKnockback extends Module {
         if(hitEntity == null) return;
         if(!(hitEntity instanceof Player)) return;
 
+        // Do not move Citizens NPCs
+        // See https://wiki.citizensnpcs.co/API#Checking_if_an_entity_is_a_Citizens_NPC
+        if(hitEntity.hasMetadata("NPC")) return;
+
         FishHook hook = (FishHook) hookEntity;
         Player rodder = (Player) hook.getShooter();
         Player player = (Player) hitEntity;


### PR DESCRIPTION
## Problem
Fishing rods were moving Citizens NPCs, as they masquerade as real bukkit CraftPlayers.

## Solution
Per their [wiki](https://wiki.citizensnpcs.co/API#Checking_if_an_entity_is_a_Citizens_NPC) it now checks whether the entity is an NPC before moving.

## Possible complications
Players with the NPC metadata. Probably not going to happen

## Further work
Maybe some other module should also not be applied, if an NPC executed it?