### PR TITLE
Chorus fruit control

### DIFF
--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleChorusFruit.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleChorusFruit.java
@@ -1,0 +1,180 @@
+package gvlfm78.plugin.OldCombatMechanics.module;
+
+import gvlfm78.plugin.OldCombatMechanics.OCMMain;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.Vector;
+
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * A module to control chorus fruits.
+ */
+public class ModuleChorusFruit extends Module {
+
+    public static final String LAST_TELEPORT_METADATA_KEY = "last-chorous-teleport";
+
+    /**
+     * Creates a new module.
+     *
+     * @param plugin the plugin instance
+     */
+    public ModuleChorusFruit(OCMMain plugin){
+        super(plugin, "chorus-fruit");
+    }
+
+    private double getMaxTeleportationDistance(){
+        return module().getDouble("max-teleportation-distance");
+    }
+
+    @EventHandler
+    public void onEat(PlayerItemConsumeEvent e){
+        if(e.getItem().getType() != Material.CHORUS_FRUIT){
+            return;
+        }
+        if(module().getBoolean("prevent-eating")){
+            e.setCancelled(true);
+            return;
+        }
+
+        int hungerValue = module().getInt("hunger-value");
+        double saturationValue = module().getDouble("saturation-value");
+
+        int previousFoodLevel = e.getPlayer().getFoodLevel();
+        float previousSaturation = e.getPlayer().getSaturation();
+
+        // Run it on the next tick to reset things while not cancelling the chorus fruit eat event
+        // This ensures the teleport event is fired and it counts towards statistics
+        new BukkitRunnable() {
+            @Override
+            public void run(){
+                int newFoodLevel = Math.min(hungerValue + previousFoodLevel, 20);
+                float newSaturation = Math.min((float) (saturationValue + previousSaturation), newFoodLevel);
+
+                e.getPlayer().setFoodLevel(newFoodLevel);
+                e.getPlayer().setSaturation(newSaturation);
+
+                debug(
+                        "Food level changed from: " + previousFoodLevel + " to " + e.getPlayer().getFoodLevel(),
+                        e.getPlayer()
+                );
+            }
+        }.runTaskLater(plugin, 2);
+    }
+
+    @EventHandler
+    public void onTeleport(PlayerTeleportEvent e){
+        if(!e.getCause().name().equals("CHORUS_FRUIT")){
+            return;
+        }
+
+        if(getMaxTeleportationDistance() == 8){
+            debug("Using vanilla teleport implementation!", e.getPlayer());
+            return;
+        }
+
+        e.setCancelled(true);
+
+        if(getMaxTeleportationDistance() <= 0){
+            debug("Chorus teleportation is not allowed", e.getPlayer());
+            return;
+        }
+
+        // Not sure when this can occur, but it is marked as @Nullable
+        if(e.getTo() == null){
+            debug("Teleport target is null", e.getPlayer());
+            return;
+        }
+
+        for(int i = 0; i < module().getInt("max-teleport-tries"); i++){
+            Optional<Location> freeSpot = findFreeSpotWithinDistance(e.getFrom(), getMaxTeleportationDistance());
+            if(freeSpot.isPresent()){
+                Bukkit.getScheduler().runTaskLater(plugin, () -> teleportPlayer(freeSpot.get(), e.getPlayer()), 1);
+                return;
+            }
+        }
+    }
+
+    private void teleportPlayer(Location target, Player player){
+        Location from = player.getLocation();
+        player.teleport(target.clone().setDirection(player.getLocation().getDirection()));
+
+        World world = target.getWorld();
+
+        world.playSound(target, Sound.ITEM_CHORUS_FRUIT_TELEPORT, 1, 1);
+        player.playSound(target, Sound.ITEM_CHORUS_FRUIT_TELEPORT, 1, 1);
+
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        double width = 0.6;
+        double height = 1.8;
+
+        // Litter the way with portal dots
+        for(int i = 0; i < 128; ++i){
+            // Current step on the way from player to target
+            double step = i / 127.0;
+
+            // Particle offsets (just make them a bit random)
+            float offsetX = (random.nextFloat() - 0.5f) * 0.2f;
+            float offsetY = (random.nextFloat() - 0.5f) * 0.2f;
+            float offsetZ = (random.nextFloat() - 0.5f) * 0.2f;
+
+            // lerp x, y and z and add some random offset to prevent a uniform line
+            double x = lerp(from.getX(), target.getX(), step) + (random.nextDouble() - 0.5) * width * 2.0;
+            double y = lerp(from.getY(), target.getY(), step) + random.nextDouble() * height;
+            double z = lerp(from.getZ(), target.getZ(), step) + (random.nextDouble() - 0.5) * width * 2.0;
+
+            world.spawnParticle(Particle.PORTAL, x, y, z, 1, offsetX, offsetY, offsetZ);
+        }
+    }
+
+    private double lerp(double start, double end, double step){
+        return start + (end - start) * step;
+    }
+
+    private Optional<Location> findFreeSpotWithinDistance(Location center, double maxAxisDistance){
+        Vector randomVector = new Vector(
+                ThreadLocalRandom.current().nextDouble(-maxAxisDistance, maxAxisDistance),
+                ThreadLocalRandom.current().nextDouble(-maxAxisDistance, maxAxisDistance),
+                ThreadLocalRandom.current().nextDouble(-maxAxisDistance, maxAxisDistance)
+        );
+
+        Location randomPoint = center.getBlock().getLocation().add(randomVector);
+
+        while(!randomPoint.getBlock().getType().isSolid()){
+            randomPoint.subtract(0, 1, 0);
+            // At the bottom of thw word, we could go on forever otherwise
+            if(randomPoint.getY() <= 0){
+                return Optional.empty();
+            }
+        }
+
+        // Now we are at the top block, so add one to get the air space
+        randomPoint.add(0, 1, 0);
+
+        // We were in a block
+        if(randomPoint.getBlock().getType().isSolid()){
+            return Optional.empty();
+        }
+
+        // We want to be able to stay there
+        if(!randomPoint.clone().add(0, 1, 0).getBlock().isPassable()){
+            return Optional.empty();
+        }
+
+        if(randomPoint.getBlock().getType() == Material.WATER || randomPoint.getBlock().getType() == Material.LAVA){
+            return Optional.empty();
+        }
+
+        return Optional.of(randomPoint);
+    }
+}

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleChorusFruit.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleChorusFruit.java
@@ -14,8 +14,6 @@ import java.util.concurrent.ThreadLocalRandom;
  */
 public class ModuleChorusFruit extends Module {
 
-    public static final String LAST_TELEPORT_METADATA_KEY = "last-chorous-teleport";
-
     /**
      * Creates a new module.
      *

--- a/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleChorusFruit.java
+++ b/src/main/java/gvlfm78/plugin/OldCombatMechanics/module/ModuleChorusFruit.java
@@ -1,20 +1,12 @@
 package gvlfm78.plugin.OldCombatMechanics.module;
 
 import gvlfm78.plugin.OldCombatMechanics.OCMMain;
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.Particle;
-import org.bukkit.Sound;
-import org.bukkit.World;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.util.Vector;
 
-import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -78,15 +70,16 @@ public class ModuleChorusFruit extends Module {
             return;
         }
 
-        if(getMaxTeleportationDistance() == 8){
+        double distance = getMaxTeleportationDistance();
+
+        if(distance == 8){
             debug("Using vanilla teleport implementation!", e.getPlayer());
             return;
         }
 
-        e.setCancelled(true);
-
-        if(getMaxTeleportationDistance() <= 0){
+        if(distance <= 0){
             debug("Chorus teleportation is not allowed", e.getPlayer());
+            e.setCancelled(true);
             return;
         }
 
@@ -96,85 +89,15 @@ public class ModuleChorusFruit extends Module {
             return;
         }
 
-        for(int i = 0; i < module().getInt("max-teleport-tries"); i++){
-            Optional<Location> freeSpot = findFreeSpotWithinDistance(e.getFrom(), getMaxTeleportationDistance());
-            if(freeSpot.isPresent()){
-                Bukkit.getScheduler().runTaskLater(plugin, () -> teleportPlayer(freeSpot.get(), e.getPlayer()), 1);
-                return;
-            }
-        }
+        int maxheight = e.getTo().getWorld().getMaxHeight();
+        e.setTo(e.getPlayer().getLocation().add(
+                ThreadLocalRandom.current().nextDouble(-distance, distance),
+                clamp(ThreadLocalRandom.current().nextDouble(-distance, distance), 0, maxheight - 1),
+                ThreadLocalRandom.current().nextDouble(-distance, distance)
+        ));
     }
 
-    private void teleportPlayer(Location target, Player player){
-        Location from = player.getLocation();
-        player.teleport(target.clone().setDirection(player.getLocation().getDirection()));
-
-        World world = target.getWorld();
-
-        world.playSound(target, Sound.ITEM_CHORUS_FRUIT_TELEPORT, 1, 1);
-        player.playSound(target, Sound.ITEM_CHORUS_FRUIT_TELEPORT, 1, 1);
-
-        ThreadLocalRandom random = ThreadLocalRandom.current();
-        double width = 0.6;
-        double height = 1.8;
-
-        // Litter the way with portal dots
-        for(int i = 0; i < 128; ++i){
-            // Current step on the way from player to target
-            double step = i / 127.0;
-
-            // Particle offsets (just make them a bit random)
-            float offsetX = (random.nextFloat() - 0.5f) * 0.2f;
-            float offsetY = (random.nextFloat() - 0.5f) * 0.2f;
-            float offsetZ = (random.nextFloat() - 0.5f) * 0.2f;
-
-            // lerp x, y and z and add some random offset to prevent a uniform line
-            double x = lerp(from.getX(), target.getX(), step) + (random.nextDouble() - 0.5) * width * 2.0;
-            double y = lerp(from.getY(), target.getY(), step) + random.nextDouble() * height;
-            double z = lerp(from.getZ(), target.getZ(), step) + (random.nextDouble() - 0.5) * width * 2.0;
-
-            world.spawnParticle(Particle.PORTAL, x, y, z, 1, offsetX, offsetY, offsetZ);
-        }
-    }
-
-    private double lerp(double start, double end, double step){
-        return start + (end - start) * step;
-    }
-
-    private Optional<Location> findFreeSpotWithinDistance(Location center, double maxAxisDistance){
-        Vector randomVector = new Vector(
-                ThreadLocalRandom.current().nextDouble(-maxAxisDistance, maxAxisDistance),
-                ThreadLocalRandom.current().nextDouble(-maxAxisDistance, maxAxisDistance),
-                ThreadLocalRandom.current().nextDouble(-maxAxisDistance, maxAxisDistance)
-        );
-
-        Location randomPoint = center.getBlock().getLocation().add(randomVector);
-
-        while(!randomPoint.getBlock().getType().isSolid()){
-            randomPoint.subtract(0, 1, 0);
-            // At the bottom of thw word, we could go on forever otherwise
-            if(randomPoint.getY() <= 0){
-                return Optional.empty();
-            }
-        }
-
-        // Now we are at the top block, so add one to get the air space
-        randomPoint.add(0, 1, 0);
-
-        // We were in a block
-        if(randomPoint.getBlock().getType().isSolid()){
-            return Optional.empty();
-        }
-
-        // We want to be able to stay there
-        if(!randomPoint.clone().add(0, 1, 0).getBlock().isPassable()){
-            return Optional.empty();
-        }
-
-        if(randomPoint.getBlock().getType() == Material.WATER || randomPoint.getBlock().getType() == Material.LAVA){
-            return Optional.empty();
-        }
-
-        return Optional.of(randomPoint);
+    private double clamp(double x, double min, double max){
+        return Math.max(Math.min(x, max), min);
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -391,12 +391,15 @@ chorus-fruit:
   # The maximum distance the fruit can teleport the player. This a PER AXIS value, so this outlines a cube with
   # 2 * max-teleportation-distance as the side length
   # Vanilla default is 8.
+  # Setting this to 0 disables chorus fruit teleport.
   max-teleportation-distance: 8
-  # Whether to prevent eating the fruit completely
+  # Whether to prevent eating the fruit completely. This also prevents the teleportation.
   prevent-eating: false
-  # The saturation value of the chorus fruit. Default is 2.4
+  # The saturation value of the chorus fruit.
+  # Vanilla default is 2.4
   saturation-value: 2.4
-  # The hunger value of the chorus fruit. Default is 4 (2 bars)
+  # The hunger value of the chorus fruit.
+  # Vanilla default is 4 (2 bars)
   hunger-value: 4
 
 ################################

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -392,6 +392,9 @@ chorus-fruit:
   # 2 * max-teleportation-distance as the side length
   # Vanilla default is 8.
   # Setting this to 0 disables chorus fruit teleport.
+  # Setting this to a value greater than 8 MIGHT CAUSE CONFLICTS with bukkit's internal anti cheat
+  # and *potentially* any other anti-cheat you use. Please make sure this is not an issue before increasing
+  # this value.
   max-teleportation-distance: 8
   # Whether to prevent eating the fruit completely. This also prevents the teleportation.
   prevent-eating: false

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,3 @@
-
 ############# OldCombatMechanics Plugin by gvlfm78 and Rayzr522 #############
 #                                                                           #
 # Bukkit Page: http://dev.bukkit.org/bukkit-plugins/oldcombatmechanics/     #
@@ -10,7 +9,7 @@
 # This is to toggle the update checker
 update-checker:
   enabled: true
-    
+
 # Enable the oldcombatmechanics.toggle permission
 # for players to individually /ocm toggle their cooldown
 enableIndividualToggle: false
@@ -18,7 +17,7 @@ enableIndividualToggle: false
 # List of interactive blocks that right clicking on will be ignored
 # This is for modules such as sword blocking and disable-elytra
 interactive: [enchantment_table,anvil,brewing_stand,trapped_chest,chest,bed,boat,fence_gate,dispenser,dropper,furnace,jukebox,ender_chest,stone_button,wood_button,beacon,tripwire_hook,hopper,daylight_detector,daylight_detector_inverted,item_frame,diode,diode_block_off,diode_block_on,redstone_comparator,redstone_comparator_off,redstone_comparator_on,acacia_door,birch_door,dark_oak_door,jungle_door,spruce_door,wood_door,workbench,bed_block,lever,trap_door,burning_furnace,spruce_fence_gate,birch_fence_gate,jungle_fence_gate,dark_oak_fence_gate,acacia_fence_gate,white_shulker_box,orange_shulker_box,magenta_shulker_box,light_blue_shulker_box,yellow_shulker_box,lime_shulker_box,pink_shulker_box,gray_shulker_box,silver_shulker_box,cyan_shulker_box,purple_shulker_box,blue_shulker_box,brown_shulker_box,green_shulker_box,red_shulker_box,black_shulker_box]
- 
+
 
 # To use the per-world feature you must specify a list of worlds in square brackets []
 # For example (names are case sensitive):
@@ -32,7 +31,7 @@ disable-attack-cooldown:
   worlds: []
   # What to set the attack speed to. Default for 1.9 is 4, at least 16 is needed for no cooldown.
   generic-attack-speed: 24
-  
+
 disable-player-collisions:
   # This is to disable player collisions
   # This is now compatible with scoreboard and tablist-editing plugins
@@ -44,14 +43,14 @@ disable-sword-sweep:
   # Particle effect is also now removed
   enabled: true
   worlds: []
-  
+
 disable-crafting:
   # Disable the crafting of specified items
   enabled: true
   worlds: []
   # List of denied items
   denied: [shield]
-  
+
 disable-offhand:
   # Disable the usage of the offhand
   # Won't affect sword-blocking module
@@ -62,29 +61,29 @@ disable-offhand:
   # List of items that should be allowed/blocked
   # Example: [diamond_sword,BOW]
   items: []
-  
+
 old-brewing-stand:
   # Automatically refuels brewing stands
   enabled: true
   worlds: []
-  
+
 no-lapis-enchantments:
   # Automatically adds lapis to enchantment tables upon opening
   enabled: false
   worlds: []
   # Whether to only allow this for players with oldcombatmechanics.nolapis permission
   usePermission: false
-  
+
 disable-elytra:
   # Do not allow players to wear elytra
   enabled: false
   worlds: []
-  
+
 disable-enderpearl-cooldown:
   # Disables enderpearl cooldown
   enabled: true
   worlds: []
-  
+
 old-tool-damage:
   # This is to set the tool damage as in pre-1.9
   # IMPORTANT: Also enable disable-sword-sweep module or sweeps will have the damage value of the weapon in hand
@@ -138,7 +137,7 @@ sword-blocking:
   noBlockingItems: []
   # Whether the above list should act as a blacklist (i.e. only items listed stop the blocking mechanic)
   blacklist: true
-  
+
 shield-damage-reduction:
   # This module allows changing the damage reduction behaviour of shields
   enabled: true
@@ -205,7 +204,7 @@ old-fishing-knockback:
   cancelDraggingIn: true
   # This is the delay in milliseconds in-between rod damage, so the player hit has time to fall back down
   hitCooldown: 1000
-  
+
 projectile-knockback:
   # This adds knockback and/or damage to players when they get hit by snowballs, eggs & enderpearls
   # This has been a Bukkit bug for so long people thought it was vanilla when it was recently patched
@@ -236,13 +235,13 @@ old-armour-strength:
   # Based on this: https://minecraft.gamepedia.com/index.php?title=Armor&oldid=909187
   enabled: true
   worlds: []
-    
+
 disable-projectile-randomness:
   # This is to remove projectile randomness while firing arrows with a bow
   # This is actually a very old feature and has been in the game for quite some time
   enabled: false
   worlds: []
-    
+
 disable-bow-boost:
   # This is to stop players from boosting themselves forward by hitting themselves
   # while running with a punch II arrow from their bow
@@ -254,7 +253,7 @@ old-potion-effects:
   # This is to restore the 1.8 potion effects and duration
   enabled: true
 
-### DURATION: (in seconds)
+  ### DURATION: (in seconds)
   potion-durations:
     regen: # Regeneration
       drinkable:
@@ -354,8 +353,8 @@ old-potion-effects:
         base: 135
         extended: 360
 
-  # 1.9+ potions
-  # Turtle Master potion currently incompatible, will just work like default
+    # 1.9+ potions
+    # Turtle Master potion currently incompatible, will just work like default
     luck:
       drinkable:
         base: 300
@@ -385,6 +384,21 @@ old-potion-effects:
     modifier: -0.5
     multiplier: false
 
+chorus-fruit:
+  # This makes the chorus fruit behaviour configurable
+  enabled: true
+  worlds: []
+  # The maximum distance the fruit can teleport the player. This a PER AXIS value, so this outlines a cube with
+  # 2 * max-teleportation-distance as the side length
+  # Vanilla default is 8.
+  max-teleportation-distance: 8
+  # Whether to prevent eating the fruit completely
+  prevent-eating: false
+  # The saturation value of the chorus fruit. Default is 2.4
+  saturation-value: 2.4
+  # The hunger value of the chorus fruit. Default is 4 (2 bars)
+  hunger-value: 4
+
 ################################
 #### SUPPORT SETTINGS BELOW ####
 ################################
@@ -394,10 +408,10 @@ support:
 ################################
 #### SPECIAL SETTINGS BELOW ####
 ################################
-  
+
 # This enables debug messages, only enable when troubleshooting
 debug:
   enabled: false
 
 # DO NOT CHANGE THIS NUMBER AS IT WILL RESET YOUR CONFIG
-config-version: 37
+config-version: 38


### PR DESCRIPTION
## Motiviation
Controlling how a chorus fruit behaves: Saturation, hunger, teleportation, etc.

## Closes
#321 

## Known problems
Distances larger than 8 cause problems with bukkits internal anti cheat (`Moved too quick`)

### Misc
Bumps the config version