### PR TITLE
fix: `disable-offhand` handling on modeset change

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleDisableOffHand.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/module/ModuleDisableOffHand.java
@@ -174,6 +174,9 @@ public class ModuleDisableOffHand extends OCMModule {
 
     @Override
     public void onModesetChange(Player player) {
+        if (!isEnabled(player))
+            return;
+
         final PlayerInventory inventory = player.getInventory();
         final ItemStack offHandItem = inventory.getItemInOffHand();
 


### PR DESCRIPTION
## Summary

When the `disable-offhand` module is disabled in the config, the plugin still acted as if the module were active whenever a player changed modesets or worlds: it sent the player a message and removed the offhand item. This PR prevents that behaviour by short-circuiting the modeset-change handler when the module is not enabled for the player.

## Problem

* **Observed behaviour:** Even with `disable-offhand` disabled globally and absent from all modesets, switching a modeset (e.g. `/ocm mode <modeset>`) or changing world triggered the module’s modeset-change handler. The handler proceeded to remove the offhand item and notify the player as if the module were active.
* **Root cause:** `onModesetChange(Player)` runs regardless of whether the module is enabled for that player; it lacks an early check for `isEnabled(player)`.

## Steps to reproduce

1. Disable `disable-offhand` in the config.
2. Put any item in the player’s offhand.
3. Run `/ocm mode <modeset>` or change world.
4. Observe that the offhand item is removed and a message is sent, despite module being disabled.

## Fix

Add an early return to `onModesetChange` so the handler exits when the module is not enabled for the player.

**Change (in `ModuleDisableOffHand.java`):**

```java
public void onModesetChange(Player player) {
    if (!isEnabled(player)) return;

    // existing logic...
}
```

## Tests

* **Manual:** With the module disabled globally / removed from all modesets:

  * Put an item in offhand and switch modeset → item remains and no message is sent.
* **Manual:** With the module enabled for a modeset:

  * Put an item in offhand and switch into that modeset → module behaves as before (message + removal).
* **Regression check:** Confirm no other module behaviour is affected; ensure usual world-change and modeset-change flows still run for modules that are enabled.

## Impact and notes

* Low-risk change: simple guard clause that only prevents the handler running when the module is disabled.
* Keeps behaviour consistent with user expectation: disabled modules should be inert.
