### PR TITLE
feat: add `unused-modules-apply-to-all-modesets` config flag

### DIFF
--- a/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/Config.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/utilities/Config.java
@@ -115,13 +115,15 @@ public class Config {
             modulesInModesets.addAll(moduleSet);
         }
 
-        // Find modules not present in any modeset
-        final Set<String> modulesNotInAnyModeset = new HashSet<>(moduleNames);
-        modulesNotInAnyModeset.removeAll(modulesInModesets);
+        if (config.getBoolean("unused-modules-apply-to-all-modesets", true)) {
+            // Find modules not present in any modeset
+            final Set<String> modulesNotInAnyModeset = new HashSet<>(moduleNames);
+            modulesNotInAnyModeset.removeAll(modulesInModesets);
 
-        // Add any module not present in any modeset to all modesets
-        for (Set<String> modeSet : modesets.values()) {
-            modeSet.addAll(modulesNotInAnyModeset);
+            // Add any module not present in any modeset to all modesets
+            for (Set<String> modeSet : modesets.values()) {
+                modeSet.addAll(modulesNotInAnyModeset);
+            }
         }
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,7 +12,6 @@
 
 modesets:
   # Modesets are lists of modules that are enabled for a player in that mode.
-  # Modules not listed in any modeset are assumed to always be available.
   # You can create, remove, and rename as many modesets as you like by modifying the list below.
   # When in PvP, the modeset of the attacker is checked first.
   # If not PvP, the modeset of the defending entity is checked.
@@ -34,6 +33,9 @@ modesets:
     - "old-critical-hits"
   new:
     - "old-golden-apples"
+
+# Whether unused modules (not in any modeset) should be applied to all modesets
+unused-modules-apply-to-all-modesets: true
 
 worlds:
   # These are the modesets available in each world.


### PR DESCRIPTION
## Summary

Introduce a configuration flag `unused-modules-apply-to-all-modesets` that controls whether modules that **are not declared in any modeset** are applied to every modeset. Default `true` preserves existing behavior; setting it to `false` makes undeclared modules inert unless explicitly added to a modeset.

## Motivation

* **Legacy behaviour:** the plugin treated any module not present in any modeset as if it applied to every modeset.
* **Problem:** server operators may want to opt out and there was no runtime option to do so.
* **Goal:** preserve backwards compatibility while providing an explicit toggle so operators can require modules to be declared to be active.

## Behaviour changes

* New config key: `unused-modules-apply-to-all-modesets: true` (default).

  * `true` (default): unchanged legacy behaviour — modules absent from all modesets apply to every modeset.
  * `false`: modules absent from all modesets are **not** applied to any modeset; they are inert unless explicitly added.

## Config changes

```yaml
# Whether unused modules (not in any modeset) should be applied to all modesets
unused-modules-apply-to-all-modesets: false
```

## Implementation notes

* Add a boolean config entry read when reloading the modesets:

```java
if (config.getBoolean("unused-modules-apply-to-all-modesets", true)) {
    // Add any module not present in any modeset to all modesets
}
```

* Keep the change localized to avoid regressions; do not alter behavior for modules explicitly present in modesets or for global enable/disable logic.

## Tests

* **Default behaviour (no config change):** leave flag unset or `true`. Remove a module from all modesets and verify it still applies to players/modesets.
* **Opt-out behaviour:** set `unused-modules-apply-to-all-modesets: false`. Remove a module from all modesets and verify it does **not** apply.
* **Explicit inclusion:** with flag `false`, add a module to a modeset and verify it only applies to that modeset.
* **Regression:** verify modules explicitly included in modesets and global enable/disable flows remain unchanged.

## Impact and risk

* Low risk. Default preserves existing behaviour; only deployments that set the flag to `false` will observe different module activation semantics.