### PR TITLE
Update PacketEvents dependency version to 2.11.2 (Release)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,7 +117,7 @@ dependencies {
     // JSR-305 annotations (javax.annotation.Nullable)
     compileOnly("com.google.code.findbugs:jsr305:3.0.2")
     // PacketEvents
-    implementation("com.github.retrooper:packetevents-spigot:2.11.2-SNAPSHOT")
+    implementation("com.github.retrooper:packetevents-spigot:2.11.2")
     // XSeries
     implementation("com.github.cryptomorin:XSeries:13.6.0")
 


### PR DESCRIPTION
PacketEvents released the 2.11.2, maybe it could be good to bump it to Release version ? :)