### PR TITLE
fix: sword blocking falling back to the shield swap on Paper 26.1.x (#892)

### DIFF
--- a/src/integrationTest/kotlin/kernitus/plugin/OldCombatMechanics/ConsumableComponentIntegrationTest.kt
+++ b/src/integrationTest/kotlin/kernitus/plugin/OldCombatMechanics/ConsumableComponentIntegrationTest.kt
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+@file:Suppress("ktlint:standard:package-name")
+
 package kernitus.plugin.OldCombatMechanics
 
 import io.kotest.common.ExperimentalKotest
@@ -74,7 +76,7 @@ class ConsumableComponentIntegrationTest :
                         player.inventory.itemInMainHand,
                         null,
                         BlockFace.SELF,
-                        EquipmentSlot.HAND,
+                        EquipmentSlot.HAND
                     )
                 Bukkit.getPluginManager().callEvent(event)
             }
@@ -210,7 +212,7 @@ class ConsumableComponentIntegrationTest :
         suspend fun withPacketEventsClientVersion(
             player: Player,
             versionName: String,
-            block: suspend () -> Unit,
+            block: suspend () -> Unit
         ) {
             val user = requirePacketEventsUser(player)
             val versionClass = packetEventsClientVersionClass()
@@ -258,7 +260,7 @@ class ConsumableComponentIntegrationTest :
             } catch (t: Throwable) {
                 throw IllegalStateException(
                     "Failed to obtain NMS ItemStack (${t::class.java.simpleName}: ${t.message})",
-                    t,
+                    t
                 )
             }
         }
@@ -279,12 +281,25 @@ class ConsumableComponentIntegrationTest :
                 val dataComponentType = Class.forName("net.minecraft.core.component.DataComponentType")
                 val dataComponents = Class.forName("net.minecraft.core.component.DataComponents")
                 val consumableType = dataComponents.getField("CONSUMABLE").get(null)
-                val getMethod = patch.javaClass.getMethod("get", dataComponentType)
-                getMethod.invoke(patch, consumableType) as? Optional<*>
+                val getMethod =
+                    try {
+                        patch.javaClass.getMethod("get", dataComponentType)
+                    } catch (_: NoSuchMethodException) {
+                        null
+                    }
+                if (getMethod != null) {
+                    getMethod.invoke(patch, consumableType) as? Optional<*>
+                } else {
+                    val entries = patch.javaClass.getMethod("entrySet").invoke(patch) as? Set<*> ?: return null
+                    entries
+                        .filterIsInstance<Map.Entry<*, *>>()
+                        .firstOrNull { it.key === consumableType }
+                        ?.value as? Optional<*>
+                }
             } catch (t: Throwable) {
                 throw IllegalStateException(
                     "Failed to inspect data component patch (${t::class.java.simpleName}: ${t.message})",
-                    t,
+                    t
                 )
             }
         }
@@ -294,14 +309,18 @@ class ConsumableComponentIntegrationTest :
             return !entry.isPresent
         }
 
-        fun nmsConsumableType(): Any = Class.forName("net.minecraft.core.component.DataComponents").getField("CONSUMABLE").get(null)
+        fun nmsConsumableType(): Any =
+            Class.forName("net.minecraft.core.component.DataComponents").getField("CONSUMABLE").get(null)
 
         fun nmsConsumableComponent(): Any {
             val nmsConsumable = Class.forName("net.minecraft.world.item.component.Consumable")
             val builder = nmsConsumable.getMethod("builder").invoke(null)
             val nmsUseAnim = Class.forName("net.minecraft.world.item.ItemUseAnimation")
             val blockAnim = nmsUseAnim.getField("BLOCK").get(null)
-            val withSeconds = builder.javaClass.getMethod("consumeSeconds", Float::class.javaPrimitiveType).invoke(builder, 1.6f)
+            val withSeconds =
+                builder.javaClass
+                    .getMethod("consumeSeconds", Float::class.javaPrimitiveType)
+                    .invoke(builder, 1.6f)
             val withAnim = withSeconds.javaClass.getMethod("animation", nmsUseAnim).invoke(withSeconds, blockAnim)
             return withAnim.javaClass.getMethod("build").invoke(withAnim)
         }
@@ -335,14 +354,14 @@ class ConsumableComponentIntegrationTest :
             } catch (t: Throwable) {
                 throw IllegalStateException(
                     "Failed to apply NMS consumable component (${t::class.java.simpleName}: ${t.message})",
-                    t,
+                    t
                 )
             }
         }
 
         fun assertNoConsumableRemoval(
             stack: ItemStack?,
-            label: String,
+            label: String
         ) {
             val entry = consumablePatchEntry(stack)
             if (entry != null && !entry.isPresent) {
@@ -352,7 +371,7 @@ class ConsumableComponentIntegrationTest :
 
         fun setModeset(
             player: Player,
-            modeset: String?,
+            modeset: String?
         ) {
             val data = getPlayerData(player.uniqueId)
             val worldId = player.world.uid
@@ -366,7 +385,7 @@ class ConsumableComponentIntegrationTest :
 
         fun syntheticPlayerDeathEvent(
             player: Player,
-            drops: MutableList<ItemStack>,
+            drops: MutableList<ItemStack>
         ): PlayerDeathEvent {
             for (ctor in PlayerDeathEvent::class.java.constructors) {
                 val args = arrayOfNulls<Any>(ctor.parameterCount)
@@ -378,7 +397,8 @@ class ConsumableComponentIntegrationTest :
                                 player
                             }
 
-                            MutableList::class.java.isAssignableFrom(paramType) || List::class.java.isAssignableFrom(paramType) -> {
+                            MutableList::class.java.isAssignableFrom(paramType) ||
+                                List::class.java.isAssignableFrom(paramType) -> {
                                 drops
                             }
 
@@ -422,7 +442,7 @@ class ConsumableComponentIntegrationTest :
 
         fun restoreSection(
             path: String,
-            value: Any?,
+            value: Any?
         ) {
             ocm.config.set(path, null)
             when (value) {
@@ -443,7 +463,7 @@ class ConsumableComponentIntegrationTest :
 
         suspend fun withWorldModesets(
             worldModesets: List<String>,
-            block: suspend () -> Unit,
+            block: suspend () -> Unit
         ) {
             val originalWorlds = runSync { snapshotSection("worlds") }
             try {
@@ -512,7 +532,7 @@ class ConsumableComponentIntegrationTest :
 
         suspend fun withSwordBlockingPaperAnimation(
             enabled: Boolean,
-            block: suspend () -> Unit,
+            block: suspend () -> Unit
         ) {
             val original = runSync { snapshotSection("sword-blocking.paper-animation") }
             try {
@@ -616,7 +636,7 @@ class ConsumableComponentIntegrationTest :
                                 InventoryType.SlotType.CONTAINER,
                                 0,
                                 ClickType.LEFT,
-                                InventoryAction.PICKUP_ALL,
+                                InventoryAction.PICKUP_ALL
                             )
                         click.currentItem = slotItem
                         click.cursor = cursorItem
@@ -666,7 +686,7 @@ class ConsumableComponentIntegrationTest :
                                 InventoryType.SlotType.CONTAINER,
                                 0,
                                 ClickType.LEFT,
-                                InventoryAction.PICKUP_ALL,
+                                InventoryAction.PICKUP_ALL
                             )
                         click.currentItem = slotItem
                         click.cursor = cursorItem
@@ -715,7 +735,7 @@ class ConsumableComponentIntegrationTest :
                             0,
                             ClickType.NUMBER_KEY,
                             InventoryAction.HOTBAR_SWAP,
-                            0,
+                            0
                         )
                     }
 
@@ -770,7 +790,7 @@ class ConsumableComponentIntegrationTest :
                                 InventoryType.SlotType.CONTAINER,
                                 0,
                                 ClickType.LEFT,
-                                InventoryAction.PICKUP_ALL,
+                                InventoryAction.PICKUP_ALL
                             )
                         click.currentItem = slotItem
                         click.cursor = cursorItem
@@ -819,7 +839,7 @@ class ConsumableComponentIntegrationTest :
                                     InventoryType.SlotType.CONTAINER,
                                     0,
                                     ClickType.LEFT,
-                                    InventoryAction.PICKUP_ALL,
+                                    InventoryAction.PICKUP_ALL
                                 )
                             click.currentItem = slotItem
                             click.cursor = cursorItem
@@ -1013,7 +1033,7 @@ class ConsumableComponentIntegrationTest :
                         PlayerSwapHandItemsEvent(
                             player,
                             player.inventory.itemInMainHand.clone(),
-                            player.inventory.itemInOffHand.clone(),
+                            player.inventory.itemInOffHand.clone()
                         )
                     }
 
@@ -1214,7 +1234,7 @@ class ConsumableComponentIntegrationTest :
                                 InventoryType.SlotType.CONTAINER,
                                 0,
                                 ClickType.MIDDLE,
-                                InventoryAction.CLONE_STACK,
+                                InventoryAction.CLONE_STACK
                             )
                         click.currentItem = gui.getItem(0)
                         click
@@ -1261,7 +1281,7 @@ class ConsumableComponentIntegrationTest :
                             ItemStack(Material.CARROT),
                             ItemStack(Material.CARROT),
                             false,
-                            mapOf(0 to ItemStack(Material.CARROT)),
+                            mapOf(0 to ItemStack(Material.CARROT))
                         )
                     }
 
@@ -1308,7 +1328,7 @@ class ConsumableComponentIntegrationTest :
                             ItemStack(Material.CARROT),
                             ItemStack(Material.CARROT),
                             false,
-                            mapOf(9 to ItemStack(Material.CARROT)),
+                            mapOf(9 to ItemStack(Material.CARROT))
                         )
                     }
 
@@ -1364,7 +1384,7 @@ class ConsumableComponentIntegrationTest :
                             ItemStack(Material.CARROT),
                             ItemStack(Material.CARROT),
                             false,
-                            mapOf(9 to ItemStack(Material.CARROT)),
+                            mapOf(9 to ItemStack(Material.CARROT))
                         )
                     }
 
@@ -1418,7 +1438,7 @@ class ConsumableComponentIntegrationTest :
                             ItemStack(Material.CARROT),
                             ItemStack(Material.CARROT),
                             false,
-                            mapOf(9 to ItemStack(Material.CARROT)),
+                            mapOf(9 to ItemStack(Material.CARROT))
                         )
                     }
 
@@ -1511,7 +1531,7 @@ class ConsumableComponentIntegrationTest :
                                     InventoryType.SlotType.CONTAINER,
                                     0,
                                     ClickType.LEFT,
-                                    InventoryAction.PICKUP_ALL,
+                                    InventoryAction.PICKUP_ALL
                                 )
                             event.currentItem = gui.getItem(0)
                             event
@@ -1556,7 +1576,7 @@ class ConsumableComponentIntegrationTest :
                             player.location,
                             ItemStack(Material.SHIELD).apply {
                                 itemMeta = itemMeta?.apply { setDisplayName("Unrelated Shield") }
-                            },
+                            }
                         )
                     }
 
@@ -1599,7 +1619,7 @@ class ConsumableComponentIntegrationTest :
                         PlayerSwapHandItemsEvent(
                             player,
                             player.inventory.itemInMainHand,
-                            player.inventory.itemInOffHand,
+                            player.inventory.itemInOffHand
                         )
                     }
 
@@ -1647,7 +1667,7 @@ class ConsumableComponentIntegrationTest :
                 val drops =
                     mutableListOf(
                         ItemStack(Material.SHIELD),
-                        ItemStack(Material.SHIELD),
+                        ItemStack(Material.SHIELD)
                     )
                 val deathEvent = runSync { syntheticPlayerDeathEvent(player, drops) }
 
@@ -1751,7 +1771,7 @@ class ConsumableComponentIntegrationTest :
                         PlayerSwapHandItemsEvent(
                             player,
                             player.inventory.itemInMainHand,
-                            player.inventory.itemInOffHand,
+                            player.inventory.itemInOffHand
                         )
                     }
 
@@ -1838,7 +1858,7 @@ class ConsumableComponentIntegrationTest :
                                 0,
                                 ClickType.NUMBER_KEY,
                                 InventoryAction.HOTBAR_SWAP,
-                                2,
+                                2
                             )
                         click.currentItem = player.inventory.getItem(0)
                         click

--- a/src/integrationTest/kotlin/kernitus/plugin/OldCombatMechanics/PaperSwordBlockingDamageReductionIntegrationTest.kt
+++ b/src/integrationTest/kotlin/kernitus/plugin/OldCombatMechanics/PaperSwordBlockingDamageReductionIntegrationTest.kt
@@ -4,12 +4,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+@file:Suppress("ktlint:standard:package-name")
+
 package kernitus.plugin.OldCombatMechanics
 
+import io.kotest.assertions.withClue
 import io.kotest.common.ExperimentalKotest
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.doubles.shouldBeLessThan
 import io.kotest.matchers.doubles.shouldBeGreaterThan
+import io.kotest.matchers.doubles.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import kernitus.plugin.OldCombatMechanics.module.ModuleSwordBlocking
 import kernitus.plugin.OldCombatMechanics.utilities.storage.PlayerStorage.getPlayerData
@@ -31,136 +34,209 @@ import org.bukkit.plugin.java.JavaPlugin
 import java.util.concurrent.Callable
 
 @OptIn(ExperimentalKotest::class)
-class PaperSwordBlockingDamageReductionIntegrationTest : FunSpec({
-    val testPlugin = JavaPlugin.getPlugin(OCMTestMain::class.java)
-    val ocm = JavaPlugin.getPlugin(OCMMain::class.java)
-    extensions(MainThreadDispatcherExtension(testPlugin))
+class PaperSwordBlockingDamageReductionIntegrationTest :
+    FunSpec({
+        val testPlugin = JavaPlugin.getPlugin(OCMTestMain::class.java)
+        val ocm = JavaPlugin.getPlugin(OCMMain::class.java)
+        extensions(MainThreadDispatcherExtension(testPlugin))
 
-    fun <T> runSync(action: () -> T): T {
-        return if (Bukkit.isPrimaryThread()) action() else Bukkit.getScheduler()
-            .callSyncMethod(testPlugin, Callable { action() })
-            .get()
-    }
+        fun <T> runSync(action: () -> T): T =
+            if (Bukkit.isPrimaryThread()) {
+                action()
+            } else {
+                Bukkit
+                    .getScheduler()
+                    .callSyncMethod(testPlugin, Callable { action() })
+                    .get()
+            }
 
-    suspend fun delayTicks(ticks: Long) {
-        delay(ticks * 50L)
-    }
-
-    fun paperDataComponentApiPresent(): Boolean {
-        return try {
-            Class.forName("io.papermc.paper.datacomponent.DataComponentTypes")
-            true
-        } catch (_: Throwable) {
-            false
-        }
-    }
-
-    fun setModeset(player: Player, name: String) {
-        val data = getPlayerData(player.uniqueId)
-        data.setModesetForWorld(player.world.uid, name)
-        setPlayerData(player.uniqueId, data)
-    }
-
-    fun equipSword(player: Player, material: Material) {
-        player.inventory.setItemInMainHand(ItemStack(material))
-        player.updateInventory()
-    }
-
-    fun rightClickMainHand(player: Player) {
-        val event = PlayerInteractEvent(
-            player,
-            Action.RIGHT_CLICK_AIR,
-            player.inventory.itemInMainHand,
-            null,
-            org.bukkit.block.BlockFace.SELF,
-            EquipmentSlot.HAND
-        )
-        Bukkit.getPluginManager().callEvent(event)
-    }
-
-    lateinit var defenderFake: FakePlayer
-    lateinit var defender: Player
-    lateinit var module: ModuleSwordBlocking
-
-    beforeSpec {
-        runSync {
-            module = ModuleLoader.getModules().filterIsInstance<ModuleSwordBlocking>().firstOrNull()
-                ?: error("ModuleSwordBlocking not registered")
-
-            val world = Bukkit.getWorld("world") ?: error("world missing")
-            val base = Location(world, 0.0, 100.0, 0.0)
-
-            defenderFake = FakePlayer(testPlugin)
-            defenderFake.spawn(base)
-            defender = Bukkit.getPlayer(defenderFake.uuid) ?: error("defender not found")
-
-            defender.gameMode = GameMode.SURVIVAL
-            defender.maximumNoDamageTicks = 20
-            defender.noDamageTicks = 0
-            defender.isInvulnerable = false
-            defender.inventory.clear()
-            setModeset(defender, "old")
-        }
-    }
-
-    afterSpec {
-        runSync {
-            defenderFake.removePlayer()
-        }
-    }
-
-    test("Paper sword blocking sets BLOCKING modifier negative on hit") {
-        if (!paperDataComponentApiPresent()) {
-            println("Skipping: Paper DataComponent API not present")
-            return@test
+        suspend fun delayTicks(ticks: Long) {
+            delay(ticks * 50L)
         }
 
-        runSync {
-            equipSword(defender, Material.DIAMOND_SWORD)
-            defender.inventory.setItemInOffHand(ItemStack(Material.AIR))
+        fun paperDataComponentApiPresent(): Boolean =
+            try {
+                Class.forName("io.papermc.paper.datacomponent.DataComponentTypes")
+                true
+            } catch (_: Throwable) {
+                false
+            }
+
+        fun setModeset(
+            player: Player,
+            name: String
+        ) {
+            val data = getPlayerData(player.uniqueId)
+            data.setModesetForWorld(player.world.uid, name)
+            setPlayerData(player.uniqueId, data)
         }
 
-        runSync { rightClickMainHand(defender) }
-        delayTicks(2)
-
-        val offhandAfter = runSync { defender.inventory.itemInOffHand.type }
-        if (offhandAfter == Material.SHIELD) {
-            println("Skipping: legacy shield swap path is active on this server")
-            return@test
+        fun equipSword(
+            player: Player,
+            material: Material
+        ) {
+            player.inventory.setItemInMainHand(ItemStack(material))
+            player.updateInventory()
         }
 
-        runSync {
-            // The bug we saw in live logs: the sword can animate as BLOCK, but the server may not recognise
-            // it as "blocking" for damage reduction (BLOCKING stays 0). This asserts the Paper path is
-            // actually recognised server-side.
-            module.isPaperSwordBlocking(defender) shouldBe true
-        }
-
-        val zombie = runSync {
-            defender.world.spawn(defender.location.clone().add(0.0, 0.0, 1.0), org.bukkit.entity.Zombie::class.java)
-        }
-        try {
-            // Use a synthetic event here. We specifically care about the Paper sword-block detection and the
-            // computed reduction. Whether Bukkit considers the BLOCKING modifier "applicable" is decided by
-            // the server's internal damage pipeline and can differ for synthetic events vs real hits.
-            val event = runSync {
-                org.bukkit.event.entity.EntityDamageByEntityEvent(
-                    zombie,
-                    defender,
-                    EntityDamageEvent.DamageCause.ENTITY_ATTACK,
-                    2.5
+        fun rightClickMainHand(player: Player) {
+            val event =
+                PlayerInteractEvent(
+                    player,
+                    Action.RIGHT_CLICK_AIR,
+                    player.inventory.itemInMainHand,
+                    null,
+                    org.bukkit.block.BlockFace.SELF,
+                    EquipmentSlot.HAND
                 )
+            Bukkit.getPluginManager().callEvent(event)
+        }
+
+        fun describeBlockingState(player: Player): String =
+            try {
+                val handle = player.javaClass.getMethod("getHandle").invoke(player)
+                val useItem = handle.javaClass.getMethod("getUseItem").invoke(handle)
+                val isEmpty = useItem?.javaClass?.getMethod("isEmpty")?.invoke(useItem)
+                val tag = Class.forName("net.minecraft.tags.ItemTags").getField("SWORDS").get(null)
+                val holderInfo =
+                    try {
+                        val holderMethod =
+                            try {
+                                useItem.javaClass.getMethod("getItemHolder")
+                            } catch (_: NoSuchMethodException) {
+                                useItem.javaClass.getMethod("typeHolder")
+                            }
+                        val holder = holderMethod.invoke(useItem)
+                        val holderClass = Class.forName("net.minecraft.core.Holder")
+                        val tagKeyClass = Class.forName("net.minecraft.tags.TagKey")
+                        val holderIs = holderClass.getMethod("is", tagKeyClass)
+                        "holder=$holder isSwordTag=${holderIs.invoke(holder, tag)}"
+                    } catch (t: Throwable) {
+                        "holderCheckFailed=${t::class.java.simpleName}: ${t.message}"
+                    }
+                "useItem=$useItem empty=$isEmpty handRaised=${player.isHandRaised} " +
+                    "blocking=${player.isBlocking} $holderInfo"
+            } catch (t: Throwable) {
+                "stateCheckFailed=${t::class.java.simpleName}: ${t.message}"
             }
 
-            val reduction = runSync { module.applyPaperBlockingReduction(event, 2.5) }
-            reduction shouldBeGreaterThan 0.0
-            // Also sanity-check sign: the module is supposed to write BLOCKING as a negative modifier downstream.
-            // (We don't assert it here because synthetic events may not expose/apply that modifier consistently.)
-            reduction shouldBeLessThan 2.5
-        } finally {
+        fun describeAdapterState(
+            module: ModuleSwordBlocking,
+            player: Player
+        ): String =
+            try {
+                val adapterField = ModuleSwordBlocking::class.java.getDeclaredField("paperAdapter")
+                adapterField.isAccessible = true
+                val adapter = adapterField.get(module) ?: return "adapter=null"
+                val handles =
+                    listOf("nmsItemStackIs", "nmsGetItemHolder", "nmsHolderIsTag").joinToString(" ") { name ->
+                        try {
+                            val f = adapter.javaClass.getDeclaredField(name)
+                            f.isAccessible = true
+                            "$name=${if (f.get(adapter) == null) "null" else "set"}"
+                        } catch (_: NoSuchFieldException) {
+                            "$name=missing"
+                        }
+                    }
+                val verdict =
+                    adapter.javaClass
+                        .getMethod("isBlockingSword", Player::class.java)
+                        .invoke(adapter, player)
+                val ocm = JavaPlugin.getPlugin(OCMMain::class.java)
+                val animationConfig = ocm.config.get("sword-blocking.paper-animation")
+                "$handles adapterIsBlockingSword=$verdict paperAnimationConfig=$animationConfig"
+            } catch (t: Throwable) {
+                "adapterCheckFailed=${t::class.java.simpleName}: ${t.message}"
+            }
+
+        lateinit var defenderFake: FakePlayer
+        lateinit var defender: Player
+        lateinit var module: ModuleSwordBlocking
+
+        beforeSpec {
             runSync {
-                zombie.remove()
+                module = ModuleLoader.getModules().filterIsInstance<ModuleSwordBlocking>().firstOrNull()
+                    ?: error("ModuleSwordBlocking not registered")
+
+                val world = Bukkit.getWorld("world") ?: error("world missing")
+                val base = Location(world, 0.0, 100.0, 0.0)
+
+                defenderFake = FakePlayer(testPlugin)
+                defenderFake.spawn(base)
+                defender = Bukkit.getPlayer(defenderFake.uuid) ?: error("defender not found")
+
+                defender.gameMode = GameMode.SURVIVAL
+                defender.maximumNoDamageTicks = 20
+                defender.noDamageTicks = 0
+                defender.isInvulnerable = false
+                defender.inventory.clear()
+                setModeset(defender, "old")
             }
         }
-    }
-})
+
+        afterSpec {
+            runSync {
+                defenderFake.removePlayer()
+            }
+        }
+
+        test("Paper sword blocking sets BLOCKING modifier negative on hit") {
+            if (!paperDataComponentApiPresent()) {
+                println("Skipping: Paper DataComponent API not present")
+                return@test
+            }
+
+            runSync {
+                equipSword(defender, Material.DIAMOND_SWORD)
+                defender.inventory.setItemInOffHand(ItemStack(Material.AIR))
+            }
+
+            runSync { rightClickMainHand(defender) }
+            delayTicks(2)
+
+            val offhandAfter = runSync { defender.inventory.itemInOffHand.type }
+            if (offhandAfter == Material.SHIELD) {
+                println("Skipping: legacy shield swap path is active on this server")
+                return@test
+            }
+
+            runSync {
+                // The bug we saw in live logs: the sword can animate as BLOCK, but the server may not recognise
+                // it as "blocking" for damage reduction (BLOCKING stays 0). This asserts the Paper path is
+                // actually recognised server-side.
+                withClue("${describeBlockingState(defender)} ${describeAdapterState(module, defender)}") {
+                    module.isPaperSwordBlocking(defender) shouldBe true
+                }
+            }
+
+            val zombie =
+                runSync {
+                    val spawnAt = defender.location.clone().add(0.0, 0.0, 1.0)
+                    defender.world.spawn(spawnAt, org.bukkit.entity.Zombie::class.java)
+                }
+            try {
+                // Use a synthetic event here. We specifically care about the Paper sword-block detection and the
+                // computed reduction. Whether Bukkit considers the BLOCKING modifier "applicable" is decided by
+                // the server's internal damage pipeline and can differ for synthetic events vs real hits.
+                val event =
+                    runSync {
+                        org.bukkit.event.entity.EntityDamageByEntityEvent(
+                            zombie,
+                            defender,
+                            EntityDamageEvent.DamageCause.ENTITY_ATTACK,
+                            2.5
+                        )
+                    }
+
+                val reduction = runSync { module.applyPaperBlockingReduction(event, 2.5) }
+                reduction shouldBeGreaterThan 0.0
+                // Also sanity-check sign: the module is supposed to write BLOCKING as a negative modifier downstream.
+                // (We don't assert it here because synthetic events may not expose/apply that modifier consistently.)
+                reduction shouldBeLessThan 2.5
+            } finally {
+                runSync {
+                    zombie.remove()
+                }
+            }
+        }
+    })

--- a/src/integrationTest/kotlin/kernitus/plugin/OldCombatMechanics/SwordBlockingIntegrationTest.kt
+++ b/src/integrationTest/kotlin/kernitus/plugin/OldCombatMechanics/SwordBlockingIntegrationTest.kt
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+@file:Suppress("ktlint:standard:package-name")
+
 package kernitus.plugin.OldCombatMechanics
 
 import io.kotest.common.ExperimentalKotest
@@ -58,7 +60,7 @@ class SwordBlockingIntegrationTest :
                         plugin,
                         Callable {
                             action()
-                        },
+                        }
                     ).get()
             }
 
@@ -84,7 +86,7 @@ class SwordBlockingIntegrationTest :
                     player.maximumNoDamageTicks = 20
                     player.noDamageTicks = 0 // remove spawn invulnerability
                     player.isInvulnerable = false
-                },
+                }
             )
         }
 
@@ -97,23 +99,24 @@ class SwordBlockingIntegrationTest :
                         player.inventory.itemInMainHand,
                         null,
                         BlockFace.SELF,
-                        EquipmentSlot.HAND,
+                        EquipmentSlot.HAND
                     )
                 Bukkit.getPluginManager().callEvent(event)
             }
 
         fun rightClickEntity(
             target: Entity,
-            hand: EquipmentSlot,
+            hand: EquipmentSlot
         ) = runSync {
             Bukkit.getPluginManager().callEvent(PlayerInteractEntityEvent(player, target, hand))
         }
 
         fun rightClickEntityAt(
             target: Entity,
-            hand: EquipmentSlot,
+            hand: EquipmentSlot
         ) = runSync {
-            Bukkit.getPluginManager().callEvent(PlayerInteractAtEntityEvent(player, target, Vector(0.0, 1.0, 0.0), hand))
+            val event = PlayerInteractAtEntityEvent(player, target, Vector(0.0, 1.0, 0.0), hand)
+            Bukkit.getPluginManager().callEvent(event)
         }
 
         fun spawnEntityTarget(): Entity =
@@ -147,7 +150,7 @@ class SwordBlockingIntegrationTest :
 
         suspend fun TestScope.withPaperAnimationEnabled(
             enabled: Boolean,
-            block: suspend TestScope.() -> Unit,
+            block: suspend TestScope.() -> Unit
         ) {
             val original = runSync { ocm.config.get("sword-blocking.paper-animation") }
             runSync {
@@ -168,7 +171,7 @@ class SwordBlockingIntegrationTest :
 
         suspend fun TestScope.withUsePermission(
             required: Boolean,
-            block: suspend TestScope.() -> Unit,
+            block: suspend TestScope.() -> Unit
         ) {
             val original = runSync { ocm.config.getBoolean("sword-blocking.use-permission") }
             runSync {
@@ -207,8 +210,24 @@ class SwordBlockingIntegrationTest :
                 plugin,
                 Runnable {
                     fakePlayer.removePlayer()
-                },
+                }
             )
+        }
+
+        "initialises the Paper consumable component path when the data component API is present" {
+            val paperDataComponentApiPresent =
+                try {
+                    Class.forName("io.papermc.paper.datacomponent.DataComponentTypes")
+                    true
+                } catch (_: Throwable) {
+                    false
+                }
+
+            if (!paperDataComponentApiPresent) {
+                println("Skipping: Paper data component API unavailable")
+            } else {
+                paperConsumablePathAvailable() shouldBe true
+            }
         }
 
         "adds blocking when right-clicking with a sword (shield on legacy, consumable on Paper)" {
@@ -223,7 +242,9 @@ class SwordBlockingIntegrationTest :
             runSync {
                 // Legacy path: module injects a shield (actual "blocking" state is client-driven).
                 // Paper path: offhand remains intact and a consumable-based use animation can surface as "hand raised".
-                (player.inventory.itemInOffHand.type == Material.SHIELD || player.isBlocking || player.isHandRaised) shouldBe true
+                val blockingStateVisible =
+                    player.inventory.itemInOffHand.type == Material.SHIELD || player.isBlocking || player.isHandRaised
+                blockingStateVisible shouldBe true
                 // Legacy path injects shield; paper path keeps offhand intact
                 setOf(Material.SHIELD, Material.AIR).contains(player.inventory.itemInOffHand.type) shouldBe true
             }
@@ -275,7 +296,10 @@ class SwordBlockingIntegrationTest :
                 delayTicks(1)
 
                 runSync {
-                    (player.inventory.itemInOffHand.type == Material.SHIELD || player.isBlocking || player.isHandRaised) shouldBe true
+                    val offhandType = player.inventory.itemInOffHand.type
+                    val blockingStateVisible =
+                        offhandType == Material.SHIELD || player.isBlocking || player.isHandRaised
+                    blockingStateVisible shouldBe true
                     setOf(Material.SHIELD, Material.AIR).contains(player.inventory.itemInOffHand.type) shouldBe true
                 }
             } finally {
@@ -317,7 +341,10 @@ class SwordBlockingIntegrationTest :
                 delayTicks(1)
 
                 runSync {
-                    (player.inventory.itemInOffHand.type == Material.SHIELD || player.isBlocking || player.isHandRaised) shouldBe true
+                    val offhandType = player.inventory.itemInOffHand.type
+                    val blockingStateVisible =
+                        offhandType == Material.SHIELD || player.isBlocking || player.isHandRaised
+                    blockingStateVisible shouldBe true
                     if (player.inventory.itemInOffHand.type == Material.SHIELD) {
                         forceRestoreViaHotbarChange()
                     }
@@ -398,7 +425,10 @@ class SwordBlockingIntegrationTest :
                 runSync {
                     // Legacy path injects a shield and sets isBlocking; Paper path keeps offhand intact and uses a
                     // consumable-based use animation which can surface as "hand raised".
-                    (player.inventory.itemInOffHand.type == Material.SHIELD || player.isBlocking || player.isHandRaised) shouldBe true
+                    val offhandType = player.inventory.itemInOffHand.type
+                    val blockingStateVisible =
+                        offhandType == Material.SHIELD || player.isBlocking || player.isHandRaised
+                    blockingStateVisible shouldBe true
                     setOf(Material.SHIELD, Material.AIR).contains(player.inventory.itemInOffHand.type) shouldBe true
                 }
             }

--- a/src/main/java/kernitus/plugin/OldCombatMechanics/paper/PaperSwordBlocking.java
+++ b/src/main/java/kernitus/plugin/OldCombatMechanics/paper/PaperSwordBlocking.java
@@ -4,7 +4,9 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import org.bukkit.Bukkit;
@@ -31,6 +33,7 @@ public class PaperSwordBlocking {
     private final MethodHandle nmsRemoveComponent;
     private final MethodHandle nmsGetComponentsPatch;
     private final MethodHandle nmsPatchGet;
+    private final MethodHandle nmsPatchEntrySet;
     private final Object addConsumablePatch;
     private final Object removeConsumablePatch;
     private final Object nmsConsumableType;
@@ -56,6 +59,8 @@ public class PaperSwordBlocking {
     private final MethodHandle craftPlayerGetHandle;
     private final MethodHandle nmsGetUseItem;
     private final MethodHandle nmsItemStackIs;
+    private final MethodHandle nmsGetItemHolder;
+    private final MethodHandle nmsHolderIsTag;
     private final Object nmsSwordTag;
 
     public PaperSwordBlocking() throws Exception {
@@ -196,7 +201,13 @@ public class PaperSwordBlocking {
         nmsRemoveComponent = lookup.unreflect(findItemStackRemoveMethod(nmsItemStack, nmsComponentType));
 
         nmsGetComponentsPatch = lookup.unreflect(nmsItemStack.getMethod("getComponentsPatch"));
-        nmsPatchGet = lookup.unreflect(nmsPatch.getMethod("get", nmsComponentType));
+        MethodHandle patchGet = null;
+        try {
+            patchGet = lookup.unreflect(nmsPatch.getMethod("get", nmsComponentType));
+        } catch (NoSuchMethodException ignored) {
+        }
+        nmsPatchGet = patchGet;
+        nmsPatchEntrySet = lookup.unreflect(nmsPatch.getMethod("entrySet"));
 
         // Detect sword blocking via active item use:
         // player.getUseItem().is(ItemTags.SWORDS)
@@ -210,7 +221,19 @@ public class PaperSwordBlocking {
 
         final Object swordTag = Class.forName("net.minecraft.tags.ItemTags").getField("SWORDS").get(null);
         nmsSwordTag = swordTag;
-        nmsItemStackIs = lookup.unreflect(findItemStackIsMethod(nmsItemStack, swordTag));
+        MethodHandle itemStackIsTag = null;
+        MethodHandle getItemHolder = null;
+        MethodHandle holderIsTag = null;
+        try {
+            itemStackIsTag = lookup.unreflect(findItemStackIsMethod(nmsItemStack, swordTag));
+        } catch (NoSuchMethodException ignored) {
+            final Method holderMethod = findItemStackHolderMethod(nmsItemStack);
+            getItemHolder = lookup.unreflect(holderMethod);
+            holderIsTag = lookup.unreflect(findHolderIsTagMethod(holderMethod.getReturnType(), swordTag));
+        }
+        nmsItemStackIs = itemStackIsTag;
+        nmsGetItemHolder = getItemHolder;
+        nmsHolderIsTag = holderIsTag;
     }
 
     private Field resolveCraftItemStackHandleField(ItemStack stack) throws NoSuchFieldException {
@@ -250,11 +273,18 @@ public class PaperSwordBlocking {
     }
 
     private Method findItemStackIsMethod(Class<?> nmsItemStackClass, Object tagInstance) throws NoSuchMethodException {
+        if (tagInstance != null) {
+            try {
+                return nmsItemStackClass.getMethod("is", tagInstance.getClass());
+            } catch (NoSuchMethodException ignored) {
+            }
+        }
         for (Method m : nmsItemStackClass.getMethods()) {
             if (!m.getName().equals("is")) continue;
             if (m.getParameterCount() != 1) continue;
             if (m.getReturnType() != boolean.class) continue;
             final Class<?> param = m.getParameterTypes()[0];
+            if (param == Object.class) continue;
             // NMS has multiple "is(...)" overloads. We specifically need the tag overload used by
             // ItemStack#is(ItemTags.SWORDS). Pick an overload whose parameter can accept the tag object.
             if (tagInstance != null && param.isInstance(tagInstance)) {
@@ -269,6 +299,44 @@ public class PaperSwordBlocking {
             }
         }
         throw new NoSuchMethodException("ItemStack#is(tag) not found");
+    }
+
+    private Method findItemStackHolderMethod(Class<?> nmsItemStackClass) throws NoSuchMethodException {
+        for (String name : new String[]{"getItemHolder", "typeHolder"}) {
+            try {
+                return nmsItemStackClass.getMethod(name);
+            } catch (NoSuchMethodException ignored) {
+            }
+        }
+        for (Method m : nmsItemStackClass.getMethods()) {
+            if (m.getParameterCount() != 0) continue;
+            if (!"net.minecraft.core.Holder".equals(m.getReturnType().getName())) continue;
+            return m;
+        }
+        throw new NoSuchMethodException("ItemStack item holder accessor not found");
+    }
+
+    private Method findHolderIsTagMethod(Class<?> holderClass, Object tagInstance) throws NoSuchMethodException {
+        if (tagInstance != null) {
+            try {
+                return holderClass.getMethod("is", tagInstance.getClass());
+            } catch (NoSuchMethodException ignored) {
+            }
+        }
+        for (Method m : holderClass.getMethods()) {
+            if (!m.getName().equals("is")) continue;
+            if (m.getParameterCount() != 1) continue;
+            if (m.getReturnType() != boolean.class) continue;
+            final Class<?> param = m.getParameterTypes()[0];
+            if (param == Object.class) continue;
+            if (tagInstance != null && param.isInstance(tagInstance)) {
+                return m;
+            }
+            if (param.getName().contains("TagKey")) {
+                return m;
+            }
+        }
+        throw new NoSuchMethodException("Holder#is(tag) not found");
     }
 
     public void applyComponents(ItemStack stack) {
@@ -394,9 +462,21 @@ public class PaperSwordBlocking {
             if (nms == null) return false;
             final Object patch = nmsGetComponentsPatch.invoke(nms);
             if (patch == null) return false;
-            final Object entry = nmsPatchGet.invoke(patch, nmsConsumableType);
-            if (!(entry instanceof Optional)) return false;
-            return ((Optional<?>) entry).isPresent();
+            if (nmsPatchGet != null) {
+                final Object entry = nmsPatchGet.invoke(patch, nmsConsumableType);
+                if (!(entry instanceof Optional)) return false;
+                return ((Optional<?>) entry).isPresent();
+            }
+            final Object entries = nmsPatchEntrySet.invoke(patch);
+            if (!(entries instanceof Set)) return false;
+            for (final Object entryObject : (Set<?>) entries) {
+                if (!(entryObject instanceof Map.Entry)) continue;
+                final Map.Entry<?, ?> entry = (Map.Entry<?, ?>) entryObject;
+                if (entry.getKey() != nmsConsumableType) continue;
+                final Object value = entry.getValue();
+                return value instanceof Optional && ((Optional<?>) value).isPresent();
+            }
+            return false;
         } catch (Throwable ignored) {
             return false;
         }
@@ -510,7 +590,12 @@ public class PaperSwordBlocking {
             if (nmsPlayer == null) return false;
             final Object useItem = nmsGetUseItem.invoke(nmsPlayer);
             if (useItem == null) return false;
-            return (boolean) nmsItemStackIs.invoke(useItem, nmsSwordTag);
+            if (nmsItemStackIs != null) {
+                return (boolean) nmsItemStackIs.invoke(useItem, nmsSwordTag);
+            }
+            final Object holder = nmsGetItemHolder.invoke(useItem);
+            if (holder == null) return false;
+            return (boolean) nmsHolderIsTag.invoke(holder, nmsSwordTag);
         } catch (Throwable ignored) {
             return false;
         }


### PR DESCRIPTION
Fixes #892:

In my testing, on Paper 26.1.X and forks (not sure how kernitus successfully got it working on 26.1.1) the plugin fails to utilize sword blocking animation override via the consumable api even though the server fully supports the Paper data component API.

After review of the unobfuscated 26.1.x API changes and server jar, Minecraft 26.1.x changed two NMS signatures that are resolved reflectively in the plugin. This causes the error on startup.

For clarity:
* DataComponentPatch#get(DataComponentType) no longer exists and is now get(DataComponentGetter, DataComponentType)
* ItemStack#is(TagKey) moved to the new TypedInstance super-interface (plugin must now support this).

I'm not sure if this is the absolute best way to fix the problem but this is what I have done:
* DataComponentPatch#get is now resolved leniently; when it's absent the consumable presence check walks `entrySet()` instead, which exists on every version with data components (1.20.5 through 26.x).
* The tag check resolves the exact `is(TagKey)` overload via `getMethod` first, then a search skips Object-typed parameters so erased generic overloads can't shadow the real one. If no is(tag) overload exists at all, it falls back to typeHolder()/getItemHolder() + Holder#is(TagKey). This should be good for cross-version.

I have confirmed the fix in-game on a Paper 26.1.2 server: blocking animates with no offhand shield, and blocked hits take reduced damage. Everything operates exactly as intended. A prebuilt fixed jar can be downloaded below.
[OCM_FIXED_BUILDTEST.jar.zip](https://github.com/user-attachments/files/28575398/OCM_FIXED_BUILDTEST.jar.zip)